### PR TITLE
Sort by weight

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Features
 * lightweight: only one module
 * tested: tests itself and has complete test coverage
 * complements pyflakes and has the same output syntax
+* sort unused code items by relative weight
 * supports Python 2.6, 2.7 and 3.x
 
 
@@ -63,6 +64,13 @@ given files. While traversing all syntax trees it records the names of
 defined and used objects. Afterwards, it reports the objects which have
 been defined, but not used. This analysis ignores scopes and focuses
 only on object names.
+
+What does weight mean?
+----------------------
+
+When using the ``--weight`` option, vulture will sort the unused items by
+the relative sizes of their syntax trees, which is a proxy for the amount of code.
+This feature helps developers prioritize where to look to remove code first.
 
 
 Similar programs

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,6 +1,8 @@
 import pytest
 
+import ast
 from vulture import Vulture
+from vulture.core import estimate_lines
 
 
 @pytest.fixture
@@ -25,10 +27,57 @@ class Foo(object):
     def bar():
         pass
 
+    @staticmethod
     def func():
         if "foo" == "bar":
             return "xyz"
         import sys
         return len(sys.argv)
 """)
-    assert wv.defined_classes[0].size == 8
+    assert wv.defined_classes[0].size == 9
+
+def test_estimate_lines():
+    example = """
+def identity(o):
+    return o
+
+@identity
+class Foo(object):
+    @identity
+    @identity
+    def bar(self):
+        if "a" == "b":
+            pass
+        elif "b" == "c":
+            pass
+        else:
+            pass
+        with open("/dev/null") as f:
+            f.write("")
+        import sys
+        while "b" > "a":
+            pass
+        else:
+            pass
+        for arg in sys.argv:
+            if arg == "foo":
+                break
+        else:
+            pass
+        try:
+            x = sys.argv[99]
+        except IndexError:
+            pass
+        except Exception:
+            pass
+        else:
+            pass
+        try:
+            1/0
+        finally:
+            return 99
+"""
+    node = ast.parse(example)
+    # TODO improve estimate_lines to count the "else" clauses
+    # and the estimate will get better (higher).
+    assert estimate_lines(node) == 33

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -5,10 +5,10 @@ from vulture import Vulture
 
 @pytest.fixture
 def wv():
-    return Vulture(verbose=True, weigh=True)
+    return Vulture(verbose=True, sort_by_size=True)
 
 
-def test_weigh_function(wv):
+def test_size_function(wv):
     wv.scan("""\
 def func():
     if "foo" == "bar":
@@ -16,10 +16,10 @@ def func():
     import sys
     return len(sys.argv)
 """)
-    assert wv.defined_funcs[0].weight == 5
+    assert wv.defined_funcs[0].size == 5
 
 
-def test_weigh_class(wv):
+def test_size_class(wv):
     wv.scan("""\
 class Foo(object):
     def bar():
@@ -31,4 +31,4 @@ class Foo(object):
         import sys
         return len(sys.argv)
 """)
-    assert wv.defined_classes[0].weight == 8
+    assert wv.defined_classes[0].size == 8

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -36,6 +36,7 @@ class Foo(object):
 """)
     assert wv.defined_classes[0].size == 9
 
+
 def test_estimate_lines():
     example = """
 def identity(o):

--- a/tests/test_weighting.py
+++ b/tests/test_weighting.py
@@ -14,7 +14,7 @@ def func():
     if "foo" == "bar":
         return "xyz"
     import sys
-    print sys.argv
+    return len(sys.argv)
 """)
     assert wv.defined_funcs[0].weight == 5
 
@@ -29,7 +29,7 @@ class Foo(object):
         if "foo" == "bar":
             return "xyz"
         import sys
-        print sys.argv
+        return len(sys.argv)
 """)
     assert wv.defined_classes[0].weight == 8
 

--- a/tests/test_weighting.py
+++ b/tests/test_weighting.py
@@ -1,0 +1,35 @@
+import pytest
+
+from vulture import Vulture
+
+
+@pytest.fixture
+def wv():
+    return Vulture(verbose=True, weigh=True)
+
+
+def test_weigh_function(wv):
+    wv.scan("""\
+def func():
+    if "foo" == "bar":
+        return "xyz"
+    import sys
+    print sys.argv
+""")
+    assert wv.defined_funcs[0].weight == 5
+
+
+def test_weigh_class(wv):
+    wv.scan("""\
+class Foo(object):
+    def bar():
+        pass
+
+    def func():
+        if "foo" == "bar":
+            return "xyz"
+        import sys
+        print sys.argv
+""")
+    assert wv.defined_classes[0].weight == 8
+

--- a/tests/test_weighting.py
+++ b/tests/test_weighting.py
@@ -32,4 +32,3 @@ class Foo(object):
         return len(sys.argv)
 """)
     assert wv.defined_classes[0].weight == 8
-

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -64,11 +64,18 @@ TRAVERSABLE_FIELDS = {
         ast.FunctionDef: ('body', 'decorator_list'),
         ast.If: ('body', 'orelse'),
         ast.Module: ('body',),
-        ast.TryExcept: ('body', 'handlers', 'orelse'),
-        ast.TryFinally: ('body', 'finalbody'),
         ast.While: ('body', 'orelse'),
         ast.With: ('body',),
 }
+if sys.version_info.major == 2:
+    TRAVERSABLE_FIELDS.update({
+        ast.TryExcept: ('body', 'handlers', 'orelse'),
+        ast.TryFinally: ('body', 'finalbody'),
+    })
+if sys.version_info.major == 3:
+    TRAVERSABLE_FIELDS.update({
+        ast.Try: ('body', 'handlers', 'orelse', 'finalbody')
+    })
 
 
 def _format_path(path):

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -67,12 +67,12 @@ TRAVERSABLE_FIELDS = {
         ast.While: ('body', 'orelse'),
         ast.With: ('body',),
 }
-if sys.version_info.major == 2:
+if sys.version_info < (3, 0):
     TRAVERSABLE_FIELDS.update({
         ast.TryExcept: ('body', 'handlers', 'orelse'),
         ast.TryFinally: ('body', 'finalbody'),
     })
-if sys.version_info.major == 3:
+else:
     TRAVERSABLE_FIELDS.update({
         ast.Try: ('body', 'handlers', 'orelse', 'finalbody')
     })


### PR DESCRIPTION
## Description
Adds the ability to sort unused items by their relative code weight. Ideally we could report the number of lines spent on a function or class, but an approximation from the size of the AST tree should be sufficient for most cases.

Notes:

- Weighty comments do not add proportional weight to an item
- Consider traversing more AST node types (currently function defs, class defs, ifs and fors)
- On the **flask** codebase weighing adds 10% run time

## Related Issue
jendrikseipp/vulture#60

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation in the README file.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
