### PR TITLE
Report code after return statements

### DIFF
--- a/tests/test_unreachable.py
+++ b/tests/test_unreachable.py
@@ -1,0 +1,65 @@
+from . import v
+
+
+def check_unreachable_lines(assertion, asserted):
+    unreachable_lines = [node.lineno for node in assertion]
+    assert unreachable_lines == asserted
+
+
+def test_assignment(v):
+    v.scan("""\
+def foo():
+    print("Hello World")
+    return
+    a = 1
+""")
+    check_unreachable_lines(v.unreachable_code, [4])
+
+
+def test_multiline_return_statements(v):
+    v.scan("""\
+def foo():
+    print("Something")
+    return (Something,
+            that,
+            spans,
+            over,
+            multiple,
+            lines)
+    print("Hello World")
+""")
+    check_unreachable_lines(v.unreachable_code, [9])
+
+
+def test_multiple_return_statements(v):
+    v.scan("""\
+def foo():
+    return something
+    return None
+    return (Some,
+           big,
+           statemnt)
+""")
+    check_unreachable_lines(v.unreachable_code, [3, 4])
+
+
+def test_pass(v):
+    v.scan("""\
+def foo():
+    return
+    pass
+    return Something
+""")
+    check_unreachable_lines(v.unreachable_code, [3])
+
+
+def test_recursive_functions(v):
+    v.scan("""\
+def foo(a):
+    if a == 1:
+        return 1
+    else:
+        return foo(a-1)
+        print("This line is never executed")
+""")
+    check_unreachable_lines(v.unreachable_code, [6])

--- a/tests/test_unreachable.py
+++ b/tests/test_unreachable.py
@@ -68,10 +68,10 @@ def foo():
 def test_recursive_functions(v):
     v.scan("""\
 def foo(a):
-    if a==1:
+    if a == 1:
         return 1
     else:
-        return foo(a-1)
+        return foo(a - 1)
         print("This line is never executed")
 """)
     check_unreachable(v, 6, 1, 'return')

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -104,7 +104,7 @@ class Item(object):
         self.filename = filename
         self.lineno = lineno
         self.size = size
-        self.message = message or "Unused {typ} '{name}'".format(**locals())
+        self.message = message or "unused {typ} '{name}'".format(**locals())
 
     def _tuple(self):
         return (self.filename, self.lineno, self.name)

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -104,8 +104,7 @@ class Item(object):
         self.filename = filename
         self.lineno = lineno
         self.size = size
-        self.message = (message if message else
-                        "Unused {typ} '{name}'".format(**locals()))
+        self.message = message or "Unused {typ} '{name}'".format(**locals())
 
     def _tuple(self):
         return (self.filename, self.lineno, self.name)
@@ -144,7 +143,7 @@ class Vulture(ast.NodeVisitor):
         self.defined_imports = get_list('import')
         self.defined_props = get_list('property')
         self.defined_vars = get_list('variable')
-        self.unreachable_code = get_list('unreachable code')
+        self.unreachable_code = get_list('unreachable_code')
 
         self.used_attrs = get_set('attribute')
         self.used_names = get_set('name')
@@ -235,10 +234,10 @@ class Vulture(ast.NodeVisitor):
             return (item.filename.lower(), item.lineno)
 
         return sorted(
-                self.unused_attrs + self.unused_classes + self.unused_funcs +
-                self.unused_imports + self.unused_props + self.unused_vars +
-                self.unreachable_code, key=by_size if self.sort_by_size
-                else by_name)
+            self.unused_attrs + self.unused_classes + self.unused_funcs +
+            self.unused_imports + self.unused_props + self.unused_vars +
+            self.unreachable_code, key=by_size if self.sort_by_size
+            else by_name)
 
     def report(self):
         """
@@ -250,6 +249,7 @@ class Vulture(ast.NodeVisitor):
                 size_report = ' ({0:d} {1})'.format(item.size, line_format)
             else:
                 size_report = ''
+
             print("{0}:{1:d}: {2}{3}".format(
                 utils.format_path(item.filename), item.lineno, item.message,
                 size_report))
@@ -422,8 +422,7 @@ class Vulture(ast.NodeVisitor):
 
     def _handle_ast_list(self, ast_list):
         """
-        Iterates over the given list of ast nodes and finds unreachable code,
-        like any code after return statemnts.
+        Find unreachable nodes in the given sequence of ast nodes.
         """
         for index, node in enumerate(ast_list):
             if isinstance(node, ast.Return):
@@ -435,10 +434,10 @@ class Vulture(ast.NodeVisitor):
                     self.unreachable_code,
                     'return',
                     first_unreachable_node.lineno,
-                    size=(
-                        lines._get_last_line_number(ast_list[-1]) -
-                        first_unreachable_node.lineno + 1),
-                    message='Unreachable code after return statement')
+                    size=lines.get_last_line_number(ast_list[-1]) -
+                    first_unreachable_node.lineno + 1,
+                    message='unreachable code after return statement')
+                return
 
     def generic_visit(self, node):
         """Called if no explicit visitor function exists for a node."""

--- a/vulture/lines.py
+++ b/vulture/lines.py
@@ -37,7 +37,7 @@ def _get_last_child_with_lineno(node):
     return None
 
 
-def _get_last_line_number(node):
+def get_last_line_number(node):
     """Estimate last line number of the given AST node.
 
     When traversing the tree, we may see a mix of nodes with line
@@ -70,7 +70,7 @@ def count_lines(node):
     size of code ending with, e.g., multiline strings and comments.
 
     """
-    return _get_last_line_number(node) - node.lineno + 1
+    return get_last_line_number(node) - node.lineno + 1
 
 
 #  def count_lines_slow(node):

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -1,3 +1,4 @@
+import ast
 import codecs
 import os
 import tokenize
@@ -35,6 +36,17 @@ def read_file(filename):
             return f.read()
     except UnicodeDecodeError as err:
         raise VultureInputException(err)
+
+
+def return_nodes_after_return(tree):
+    try:
+        for i, node in enumerate(tree.body, 0):
+            if isinstance(node, ast.Return):
+                return tree.body[i+1:]
+    except AttributeError:
+        return []
+    else:
+        return return_nodes_after_return(node)
 
 
 class LoggingList(list):

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -1,4 +1,3 @@
-import ast
 import codecs
 import os
 import tokenize
@@ -36,17 +35,6 @@ def read_file(filename):
             return f.read()
     except UnicodeDecodeError as err:
         raise VultureInputException(err)
-
-
-def return_nodes_after_return(tree):
-    try:
-        for i, node in enumerate(tree.body, 0):
-            if isinstance(node, ast.Return):
-                return tree.body[i+1:]
-    except AttributeError:
-        return []
-    else:
-        return return_nodes_after_return(node)
 
 
 class LoggingList(list):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Check and report any nodes which appear after `ast.Return` while visiting function definition.

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, please link to it here: -->
Closes: #82

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All ~~new and~~ existing tests passed.
