### PR TITLE
Travis CI: Test on latest PyPy, and also test PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 - '3.6'
 - 3.7-dev
 - pypy2.7-5.8.0
+- pypy3
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+- pypy
+- pypy3
 - '2.6'
 - '2.7'
 - '3.3'
@@ -7,8 +9,6 @@ python:
 - '3.5'
 - '3.6'
 - 3.7-dev
-- pypy
-- pypy3
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 - '3.5'
 - '3.6'
 - 3.7-dev
-- pypy2.7-5.8.0
+- pypy
 - pypy3
 
 matrix:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Test on the latest PyPy available on Travis CI, rather than pinning the version to pypy2.7-5.8.0. As it happens, `pypy` and `pypy2.7-5.8.0` are both running the same version:
```
$ python --version
Python 2.7.13 (c925e7381036, Jun 05 2017, 21:20:51)
[PyPy 5.8.0 with GCC 6.2.0 20160901]
```
```
$ python --version
Python 2.7.13 (c925e7381036, Jun 05 2017, 21:20:51)
[PyPy 5.8.0 with GCC 6.2.0 20160901]
```

* Also, I don't personally need it, but PyPy3 is also available on Travis CI.

* Move slower PyPy[3] jobs to the start so they don't hold up the build.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [n/a] My change requires a change to the documentation in the README file.
- [n/a] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
