### PR TITLE
Report while-True-else block as unreachable

### DIFF
--- a/tests/test_unreachable.py
+++ b/tests/test_unreachable.py
@@ -274,3 +274,13 @@ while True:
     print("Hello")
 """)
     check_unreachable(v, 4, 1, 'break')
+
+
+def test_while_true_else(v):
+    v.scan("""\
+while True:
+    print("I won't stop")
+else:
+    print("I won't run")
+""")
+    check_unreachable(v, 4, 1, 'else')

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -437,6 +437,13 @@ class Vulture(ast.NodeVisitor):
                     self.used_attrs.add(attr)
 
     def visit_While(self, node):
+        else_body = getattr(node, 'orelse')
+        if utils.condition_is_always_true(node.test) and else_body:
+            self._define(
+                self.unreachable_code, 'else', else_body[0],
+                last_node=else_body[-1],
+                message="unreachable 'else' block",
+                confidence=100)
         if utils.condition_is_always_false(node.test):
             self._define(self.unreachable_code, 'while', node,
                          message="unsatisfiable 'while' condition",


### PR DESCRIPTION
When a while loop encounters a `True` statement, report `else` block as unreachable.

Closes: #100 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
