### PR TITLE
Ignore pytest_cache and swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vulture.egg-info/
 .cache/
 .coverage
 .tox/
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ htmlcov/
 vulture.egg-info/
 .cache/
 .coverage
-.tox/
 .pytest_cache/
+.tox/


### PR DESCRIPTION
## Description

Git keeps on catching `pytest_cache/` (because of `tox`) and `.swp` files (because of `vim`). It would be great if we could ignore these.