### PR TITLE
Skip async tests correctly

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,6 +9,10 @@ DIR = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(DIR)
 WHITELISTS = glob.glob(os.path.join(REPO, 'vulture', 'whitelists', '*.py'))
 
+skip_if_not_has_async = pytest.mark.skipif(
+    not hasattr(ast, 'AsyncFunctionDef'),
+    reason="needs async support (added in Python 3.5)")
+
 
 def check(items_or_names, expected_names):
     if isinstance(items_or_names, set):
@@ -27,12 +31,6 @@ def check_unreachable(v, lineno, size, name):
     assert item.first_lineno == lineno
     assert item.size == size
     assert item.name == name
-
-
-def skip_if_not_has_async(function):
-    if not hasattr(ast, 'AsyncFunctionDef'):
-        pytest.mark.skip(
-            function, reason="needs async support (added in Python 3.5)")
 
 
 @pytest.fixture

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -402,7 +402,7 @@ async def test_func():
 
 async def other_func():
     pass
-""", filename='test_function_names.py')
+""", filename='function_names.py')
     check(v.defined_funcs, ['test_func', 'other_func'])
     check(v.unused_funcs, ['other_func', 'test_func'])
 


### PR DESCRIPTION
It turns out that previously every test with the decorator `skip_if_not_has_async` was skipped because the decorator wasn't defined correctly. - See https://pytest.readthedocs.io/en/reorganize-docs/new-docs/user/skipping.html

This also revealed a buggy test.

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
