### PR TITLE
Use output from coverage to prepare a whitelist

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,11 @@
 News
 ====
 
+0.29 (unreleased)
+-----------------
+* Add ``--coverage-xml`` flag for ignoring code marked as used in coverage's XML report.
+
+
 0.28 (2018-07-05)
 -----------------
 * Add ``--make-whitelist`` flag for reporting output in whitelist format (thanks @RJ722).

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Features
 * complements pyflakes and has the same output syntax
 * sorts unused classes and functions by size with ``--sort-by-size``
 * supports Python 2.7 and Python >= 3.4
+* dynamic analysis for reducing false positives with ``--coverage-xml``
 
 
 Installation
@@ -50,6 +51,7 @@ Usage
   $ python3 -m vulture myscript.py
   $ vulture myscript.py mypackage/
   $ vulture myscript.py --min-confidence 100  # Only report 100% dead code.
+  $ vulture myscript.py --coverage-xml coverage.xml  # Ignores false positives.
 
 The provided arguments may be Python files or directories. For each
 directory Vulture analyzes all contained `*.py` files.
@@ -70,6 +72,15 @@ We collect whitelists for common Python modules and packages in
 ``vulture/whitelists/`` (pull requests are welcome). If you want to
 ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 ``--exclude *settings.py,docs/``).
+
+**Using results from coverage to detect false positives**
+
+Running coverage on your program can detect which parts of the code base are
+being executed and Vulture can use this report to automatically ignore false
+positives using the following command::
+
+    $ coverage run myprogram.py && coverage.xml  # Prepare the XML report.
+    $ vulture myprogram.py --coverage-xml coverage.xml
 
 **Marking unused variables**
 
@@ -142,6 +153,23 @@ results in the following output::
 Vulture correctly reports "os" and "message" as unused, but it fails to
 detect that "greet" is actually used. The recommended method to deal with
 false positives like this is to create a whitelist Python file.
+
+**Ignoring false positives using coverage.xml**
+
+After preparing a XML report by running the following command::
+
+    $ coverage run dead_code.py & coverage xml
+
+Now, pass the ``coverage.xml`` created in the previous step as an argument to
+vulture using the following command::
+
+    $ vulture dead_code.py --coverage-xml coverage.xml
+
+This lets Vulture automatically ignore the function ``greet`` because it is
+marked as used in the ``coverage.xml``::
+
+    dead_code.py:1: unused import 'os' (90% confidence)
+    dead_code.py:8: unused variable 'message' (60% confidence)
 
 **Preparing whitelists**
 

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 
 Running coverage on your program can detect which parts of the code base are
 being executed and Vulture can use this report to automatically ignore false
-positives using the following command::
+positives using the following commands::
 
     $ coverage run myprogram.py && coverage.xml  # Prepare the XML report.
     $ vulture myprogram.py --coverage-xml coverage.xml
@@ -156,7 +156,8 @@ false positives like this is to create a whitelist Python file.
 
 **Ignoring false positives using coverage.xml**
 
-After preparing a XML report by running the following command::
+The first step would be to prepare a XML report by running the following
+command::
 
     $ coverage run dead_code.py & coverage xml
 

--- a/tests/test_coverage_xml.py
+++ b/tests/test_coverage_xml.py
@@ -1,0 +1,51 @@
+import os.path
+import subprocess
+
+import pytest
+from vulture.coverage_xml import detect_used_funcs
+
+from . import check, v
+assert v  # Silence pyflakes.
+
+
+@pytest.fixture
+def check_whitelist(v, tmpdir):
+    def test_created_whitelist(code, expected):
+        sample = os.path.normcase(str(tmpdir.join("unused_code.py")))
+        xml = str(tmpdir.join("coverage.xml"))
+        with open(sample, 'w') as f:
+            f.write(code)
+        subprocess.call(["coverage", "run", sample])
+        subprocess.call(["coverage", "xml", "-o", xml])
+        v.scavenge([sample])
+        whitelist = set(item for item in detect_used_funcs(v, xml))
+        check(whitelist, expected)
+    return test_created_whitelist
+
+
+def test_getattr_function(check_whitelist):
+    code = """\
+class Greeter:
+    def greet(self):
+        print("Hi")
+greeter = Greeter()
+greet_func = getattr(greeter, "greet")
+greet_func()
+"""
+    expected = ['greet']
+    check_whitelist(code, expected)
+
+
+def test_getattr_method(check_whitelist):
+    code = """\
+class Greeter:
+    def __init__(self):
+        greeter = getattr(self, 'greet')
+        greeter()
+
+    def greet(self):
+        print('Hi')
+Greeter()
+"""
+    expected = ['greet']
+    check_whitelist(code, expected)

--- a/vulture/coverage_xml.py
+++ b/vulture/coverage_xml.py
@@ -1,4 +1,4 @@
-import os.path
+import posixpath
 from xml.etree import ElementTree as ET
 
 from vulture import utils
@@ -6,14 +6,14 @@ from vulture import utils
 
 def parse_coverage_xml(xml):
     with open(xml) as f:
-        tree = ET.parse(f)
-    return tree
+        return ET.fromstring(f.read().lower())
 
 
 def detect_used_funcs(v, xml):
     tree = parse_coverage_xml(xml)
     for item in v.unused_funcs:
-        filename = os.path.normcase(utils.format_path(item.filename))
+        filename = posixpath.join(*utils.format_path(
+            item.filename).lower().split('\\'))
         xpath = ('./packages/package/classes/class/[@filename="{}"]'
                  '/lines/line[@hits="1"]'.format(filename))
         lines_hit = [int(

--- a/vulture/coverage_xml.py
+++ b/vulture/coverage_xml.py
@@ -1,0 +1,28 @@
+import os.path
+from xml.etree import ElementTree as ET
+
+from vulture import utils
+
+
+def parse_coverage_xml(xml):
+    with open(xml) as f:
+        tree = ET.parse(f)
+    return tree
+
+
+def detect_used_funcs(v, xml):
+    tree = parse_coverage_xml(xml)
+    for item in v.unused_funcs:
+        filename = os.path.normcase(utils.format_path(item.filename))
+        xpath = ('./packages/package/classes/class/[@filename="{}"]'
+                 '/lines/line[@hits="1"]'.format(filename))
+        lines_hit = [int(
+            node.attrib['number']) for node in tree.findall(xpath)]
+        span = item.first_lineno+1, item.last_lineno+1
+        for lineno in range(*span):
+            if lineno in lines_hit:
+                yield item
+
+
+def used_funcs(v, xml):
+    return set(item for item in detect_used_funcs(v, xml))


### PR DESCRIPTION
## Description

Cross check unused functions reported by Vulture against xml reported by coverage. If the coverage report reflects that any part of the function body (other than the `def` line) is called, it is added to the whitelist which is then printed to stdout.

## Related Issue
Closes: #109 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
