### PR TITLE
Fix typo for exclude docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ You can add used code that is reported as unused to a Python module and
 add it to the list of scanned paths. We collect whitelists for common
 Python modules and packages in ``vulture/whitelists/`` (pull requests
 are welcome). If you want to ignore a whole file or directory, use the
-``--exclude`` parameter (e.g., ``-exclude *settings.py,docs/``).
+``--exclude`` parameter (e.g., ``--exclude *settings.py,docs/``).
 
 **Marking unused variables**
 


### PR DESCRIPTION
Typo in the README.md for exclude, it's missing a "-"

## Description
Correct docs for using exclude example

## Related Issue
None

## Checklist:
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
