### PR TITLE
Compare functions' decorator against ignore names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,17 +74,17 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 **Ignoring names**
 
 You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
-starting with ``foo`` and the names ``bar`` and ``baz``. The ``--ignore-names``
-option if started with a ``@`` symbol checks for functions decorated with the
-given decorator. This is helpful for example in Flask projects, where you can
-use ``--ignore-names "@app.route"`` to ignore all functions with the
-``@app.route`` decorator.
+starting with ``foo`` and the names ``bar`` and ``baz``. Additionally, the
+``--ignore-decorators`` option should be used to ignore functions decorated
+with the given decorator. This is helpful for example in Flask projects,
+where you can use ``--ignore-names app.route`` to ignore all functions
+with the ``app.route`` decorator.
 
-We recommend using whitelists instead of ``--ignore-names`` whenever
-possible, since whitelists are automatically checked for syntactic
-correctness when passed to Vulture and sometimes you can even pass
-them to your Python interpreter and let it check that all whitelisted
-code actually still exists in your project.
+We recommend using whitelists instead of ``--ignore-names`` or
+``--ignore-decorator`` whenever possible, since whitelists are automatically
+checked for syntactic correctness when passed to Vulture and sometimes
+you can even pass them to your Python interpreter and let it check that
+all whitelisted code actually still exists in your project.
 
 **Marking unused variables**
 

--- a/README.rst
+++ b/README.rst
@@ -75,16 +75,16 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 
 You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
 starting with ``foo`` and the names ``bar`` and ``baz``. Additionally, the
-``--ignore-decorators`` option should be used to ignore functions decorated
+``--ignore-decorators`` option can be used to ignore functions decorated
 with the given decorator. This is helpful for example in Flask projects,
-where you can use ``--ignore-names "@app.route"`` to ignore all functions
-with the ``app.route`` decorator.
+where you can use ``--ignore-decorators "@app.route"`` to ignore all functions
+with the ``@app.route`` decorator.
 
 We recommend using whitelists instead of ``--ignore-names`` or
-``--ignore-decorator`` whenever possible, since whitelists are automatically
-checked for syntactic correctness when passed to Vulture and sometimes
-you can even pass them to your Python interpreter and let it check that
-all whitelisted code actually still exists in your project.
+``--ignore-decorators`` whenever possible, since whitelists are automatically
+checked for syntactic correctness when passed to Vulture and often you can
+even pass them to your Python interpreter and let it check that all
+whitelisted code actually still exists in your project.
 
 **Marking unused variables**
 

--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,10 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 
 You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
 starting with ``foo`` and the names ``bar`` and ``baz``. The ``--ignore-names``
-option also checks decorator names. This is helpful for example in Flask
-projects, where you can use ``--ignore-names app.route`` to ignore all
-functions with the ``@app.route`` decorator.
+option if started with a ``@`` symbol checks for functions decorated with the
+given decorator. This is helpful for example in Flask projects, where you can
+use ``--ignore-names "@app.route"`` to ignore all functions with the
+``@app.route`` decorator.
 
 We recommend using whitelists instead of ``--ignore-names`` whenever
 possible, since whitelists are automatically checked for syntactic

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,10 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 **Ignoring names**
 
 You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
-starting with ``foo`` and the names ``bar`` and ``baz``.
+starting with foo and the names ``bar`` and ``baz``. The ``--ignore-names``
+option also checks decorator names. This is helpful for example in Flask
+projects, where you can use ``--ignore-names app.route`` to ignore all
+functions with the ``@app.route`` decorator.
 
 We recommend using whitelists instead of ``--ignore-names`` whenever
 possible, since whitelists are automatically checked for syntactic

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,10 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 **Ignoring names**
 
 You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
-starting with ``foo`` and the names ``bar`` and ``baz``.
+starting with ``foo`` and the names ``bar`` and ``baz``. The ``--ignore-names``
+option also checks decorator names. This is helpful for example in Flask
+projects, where you can use ``--ignore-names app.route`` to ignore all
+functions with the ``@app.route`` decorator.
 
 We recommend using whitelists instead of ``--ignore-names`` whenever
 possible, since whitelists are automatically checked for syntactic

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
 starting with ``foo`` and the names ``bar`` and ``baz``. Additionally, the
 ``--ignore-decorators`` option should be used to ignore functions decorated
 with the given decorator. This is helpful for example in Flask projects,
-where you can use ``--ignore-names app.route`` to ignore all functions
+where you can use ``--ignore-names "@app.route"`` to ignore all functions
 with the ``app.route`` decorator.
 
 We recommend using whitelists instead of ``--ignore-names`` or

--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,7 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 **Ignoring names**
 
 You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
-starting with foo and the names ``bar`` and ``baz``. The ``--ignore-names``
-option also checks decorator names. This is helpful for example in Flask
-projects, where you can use ``--ignore-names app.route`` to ignore all
-functions with the ``@app.route`` decorator.
+starting with foo and the names ``bar`` and ``baz``.
 
 We recommend using whitelists instead of ``--ignore-names`` whenever
 possible, since whitelists are automatically checked for syntactic

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ ignore a whole file or directory, use the ``--exclude`` parameter (e.g.,
 **Ignoring names**
 
 You can use ``--ignore-names foo*,ba[rz]`` to let Vulture ignore all names
-starting with foo and the names ``bar`` and ``baz``.
+starting with ``foo`` and the names ``bar`` and ``baz``.
 
 We recommend using whitelists instead of ``--ignore-names`` whenever
 possible, since whitelists are automatically checked for syntactic

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -98,8 +98,11 @@ def bar():
 def foo():
     pass
 
+@bar
+@foo
 @f.foobar()
 def barfoo():
     pass
 """
     check_ignore(code, ['prop_one'], [], ['decor', 'f.foobar'])
+    check_ignore(code, ['prop_one'], [], ['@decor', '@f.foobar'])

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -4,9 +4,8 @@ from . import check, skip_if_not_has_async
 
 
 def check_ignore(code, ignore_names, ignore_decorators, expected):
-    v = core.Vulture(
-            verbose=True, ignore_names=ignore_names,
-            ignore_decorators=ignore_decorators)
+    v = core.Vulture(verbose=True, ignore_names=ignore_names,
+                     ignore_decorators=ignore_decorators)
     v.scan(code)
     check(v.get_unused_code(), expected)
 
@@ -55,6 +54,18 @@ class Foo:
         pass
 """
     check_ignore(code, ['Foo'], [], [])
+
+
+def test_class_ignore():
+    code = """\
+@bar
+class Foo:
+    pass
+
+class Bar:
+    pass
+"""
+    check_ignore(code, [], [], ['Foo', 'Bar'])
 
 
 def test_property():
@@ -112,8 +123,8 @@ def foo():
 def barfoo():
     pass
 """
-    check_ignore(code, [], ['decor', 'f.foobar'], ['prop_one'])
-    check_ignore(code, [], ['@decor', '@f.foobar'], ['prop_one'])
+    check_ignore(code, [], ['@decor', '*@f.foobar'], ['prop_one'])
+    check_ignore(code, [], ['*decor', '@*f.foobar'], ['prop_one'])
 
 
 @skip_if_not_has_async
@@ -140,7 +151,6 @@ def foo():
 """
     check_ignore(code, [], ['@bar'], [])
     check_ignore(code, [], ['@baz'], ['foo'])
-    check_ignore(code, [], ['property'], [])
     check_ignore(code, [], ['@property'], [])
 
 
@@ -153,7 +163,7 @@ def foo():
 """
     check_ignore(code, [], ['@bar'], [])
     check_ignore(code, [], ['@property'], [])
-    check_ignore(code, [], ['property'], [])
+    check_ignore(code, [], ['@b*r'], [])
     check_ignore(code, [], ['@barfoo'], ['foo'])
 
 

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -65,10 +65,12 @@ class Foo:
         return a
 
     @property
+    @bar
     def foo_bar(self):
         return 'bar'
 """
-    check_ignore(code, ['some_property', 'foo_bar'], ['Foo'], ['property'])
+    check_ignore(code, [], ['Foo'], ['@property'])
+    check_ignore(code, ['some_property', 'foo_bar'], ['Foo'], [])
 
 
 def test_attribute():
@@ -138,5 +140,17 @@ def foo():
 """
     check_ignore(code, [], [], ['@bar'])
     check_ignore(code, ['foo'], [], ['@baz'])
-    check_ignore(code, ['foo'], [], ['property'])
-    check_ignore(code, ['foo'], [], ['@property'])
+    check_ignore(code, [], [], ['property'])
+    check_ignore(code, [], [], ['@property'])
+
+
+def test_decorated_class():
+    code = """\
+@barfoo
+@foo.bar('foo')
+class Bar:
+    def __init__(self):
+        pass
+"""
+    check_ignore(code, ['Bar'], [], [])
+    check_ignore(code, [], [], ['@bar*'])

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -2,7 +2,7 @@ import pytest
 
 from vulture import core
 
-from . import check
+from . import check, skip_if_not_has_async
 
 
 @pytest.fixture
@@ -37,6 +37,17 @@ def foo_two():
 def foo():
     pass
 def bar():
+    pass
+"""
+    check_ignore(code, ['bar'], ['foo*'])
+
+
+@skip_if_not_has_async
+def test_async_function(check_ignore):
+    code = """\
+async def foobar():
+    pass
+async def bar():
     pass
 """
     check_ignore(code, ['bar'], ['foo*'])
@@ -106,3 +117,18 @@ def barfoo():
 """
     check_ignore(code, ['prop_one'], [], ['decor', 'f.foobar'])
     check_ignore(code, ['prop_one'], [], ['@decor', '@f.foobar'])
+
+
+@skip_if_not_has_async
+def test_decorated_async_functions(check_ignore):
+    code = """\
+@app.route('something')
+@foobar
+async def async_function():
+    pass
+
+@a.b.c
+async def foo():
+    pass
+"""
+    check_ignore(code, ['foo'], [], ['@app.route', '@a.b'])

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -7,8 +7,10 @@ from . import check
 
 @pytest.fixture
 def check_ignore():
-    def examine(code, ignore_names, expected):
-        v = core.Vulture(verbose=True, ignore_names=ignore_names)
+    def examine(code, expected, ignore_names=[], ignore_decorators=[]):
+        v = core.Vulture(
+                verbose=True, ignore_names=ignore_names,
+                ignore_decorators=ignore_decorators)
         v.scan(code)
         check(v.get_unused_code(), expected)
     return examine
@@ -23,7 +25,7 @@ ftobar = 3
 baz = 10000
 funny = True
 """
-    check_ignore(code, ['f?o*', 'ba[rz]'], ['funny'])
+    check_ignore(code, ['funny'], ['f?o*', 'ba[rz]'])
 
 
 def test_function(check_ignore):
@@ -37,7 +39,7 @@ def foo():
 def bar():
     pass
 """
-    check_ignore(code, ['foo*'], ['bar'])
+    check_ignore(code, ['bar'], ['foo*'])
 
 
 def test_class(check_ignore):
@@ -46,7 +48,7 @@ class Foo:
     def __init__(self):
         pass
 """
-    check_ignore(code, ['Foo'], [])
+    check_ignore(code, [], ['Foo'])
 
 
 def test_property(check_ignore):
@@ -60,7 +62,7 @@ class Foo:
     def foo_bar(self):
         return 'bar'
 """
-    check_ignore(code, ['Foo', '@property'], ['some_property', 'foo_bar'])
+    check_ignore(code, ['some_property', 'foo_bar'], ['Foo'], ['property'])
 
 
 def test_attribute(check_ignore):
@@ -70,7 +72,7 @@ class Foo:
         self.attr_foo = attr_foo
         self.attr_bar = attr_bar
 """
-    check_ignore(code, ['foo', '*_foo'], ['Foo', 'attr_bar'])
+    check_ignore(code, ['Foo', 'attr_bar'], ['foo', '*_foo'])
 
 
 def test_decorated_functions(check_ignore):
@@ -100,4 +102,4 @@ def foo():
 def barfoo():
     pass
 """
-    check_ignore(code, ['@decor', '@f.foobar'], ['prop_one'])
+    check_ignore(code, ['prop_one'], [], ['decor', 'f.foobar'])

--- a/tests/test_ignore_names.py
+++ b/tests/test_ignore_names.py
@@ -81,3 +81,33 @@ class Foo:
         self.attr_bar = attr_bar
 """
     check_ignore(code, ['foo', '*_foo'], ['Foo', 'attr_bar'])
+
+
+def test_decorated_functions(check_ignore):
+    code = """\
+def decor():
+    return help
+
+class FooBar:
+    def foobar(self):
+        return help
+
+    @property
+    def prop_one(self):
+        pass
+
+f = FooBar()
+
+@decor()
+def bar():
+    pass
+
+@f.foobar
+def foo():
+    pass
+
+@f.foobar()
+def barfoo():
+    pass
+"""
+    check_ignore(code, ['decor', 'foobar'], ['prop_one'])

--- a/tests/test_ignore_names.py
+++ b/tests/test_ignore_names.py
@@ -65,8 +65,12 @@ class Foo:
     @property
     def some_property(self, a):
         return a
+
+    @property
+    def foo_bar(self):
+        return 'bar'
 """
-    check_ignore(code, ['Foo', 'property'], ['some_property'])
+    check_ignore(code, ['Foo', 'property'], ['some_property', 'foo_bar'])
 
 
 def test_attribute(check_ignore):

--- a/tests/test_ignore_names.py
+++ b/tests/test_ignore_names.py
@@ -28,6 +28,16 @@ funny = True
 
 def test_function(check_ignore):
     code = """\
+def foo():
+    pass
+def foo_ignored():
+    pass
+"""
+    check_ignore(code, ['foo_ignored'], ['foo'])
+
+
+def test_function_glob(check_ignore):
+    code = """\
 def foo_one():
     pass
 def foo_two():
@@ -47,6 +57,16 @@ class Foo:
         pass
 """
     check_ignore(code, ['Foo'], [])
+
+
+def test_property(check_ignore):
+    code = """\
+class Foo:
+    @property
+    def some_property(self, a):
+        return a
+"""
+    check_ignore(code, ['Foo', 'property'], ['some_property'])
 
 
 def test_attribute(check_ignore):

--- a/tests/test_ignore_names.py
+++ b/tests/test_ignore_names.py
@@ -59,6 +59,20 @@ class Foo:
     check_ignore(code, ['Foo'], [])
 
 
+def test_property(check_ignore):
+    code = """\
+class Foo:
+    @property
+    def some_property(self, a):
+        return a
+
+    @property
+    def foo_bar(self):
+        return 'bar'
+"""
+    check_ignore(code, ['Foo', '@property'], ['some_property', 'foo_bar'])
+
+
 def test_attribute(check_ignore):
     code = """\
 class Foo:
@@ -67,3 +81,33 @@ class Foo:
         self.attr_bar = attr_bar
 """
     check_ignore(code, ['foo', '*_foo'], ['Foo', 'attr_bar'])
+
+
+def test_decorated_functions(check_ignore):
+    code = """\
+def decor():
+    return help
+
+class FooBar:
+    def foobar(self):
+        return help
+
+    @property
+    def prop_one(self):
+        pass
+
+f = FooBar()
+
+@decor()
+def bar():
+    pass
+
+@f.foobar
+def foo():
+    pass
+
+@f.foobar()
+def barfoo():
+    pass
+"""
+    check_ignore(code, ['@decor', '@f.foobar'], ['prop_one'])

--- a/tests/test_ignore_names.py
+++ b/tests/test_ignore_names.py
@@ -59,20 +59,6 @@ class Foo:
     check_ignore(code, ['Foo'], [])
 
 
-def test_property(check_ignore):
-    code = """\
-class Foo:
-    @property
-    def some_property(self, a):
-        return a
-
-    @property
-    def foo_bar(self):
-        return 'bar'
-"""
-    check_ignore(code, ['Foo', 'property'], ['some_property', 'foo_bar'])
-
-
 def test_attribute(check_ignore):
     code = """\
 class Foo:
@@ -81,33 +67,3 @@ class Foo:
         self.attr_bar = attr_bar
 """
     check_ignore(code, ['foo', '*_foo'], ['Foo', 'attr_bar'])
-
-
-def test_decorated_functions(check_ignore):
-    code = """\
-def decor():
-    return help
-
-class FooBar:
-    def foobar(self):
-        return help
-
-    @property
-    def prop_one(self):
-        pass
-
-f = FooBar()
-
-@decor()
-def bar():
-    pass
-
-@f.foobar
-def foo():
-    pass
-
-@f.foobar()
-def barfoo():
-    pass
-"""
-    check_ignore(code, ['decor', 'foobar'], ['prop_one'])

--- a/tests/test_ignore_names.py
+++ b/tests/test_ignore_names.py
@@ -28,16 +28,6 @@ funny = True
 
 def test_function(check_ignore):
     code = """\
-def foo():
-    pass
-def foo_ignored():
-    pass
-"""
-    check_ignore(code, ['foo_ignored'], ['foo'])
-
-
-def test_function_glob(check_ignore):
-    code = """\
 def foo_one():
     pass
 def foo_two():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ def check_get_decorater_name():
 
         node_visitor = ast.NodeVisitor()
         node_visitor.visit_FunctionDef = visit_FunctionDef
+        node_visitor.visit_AsyncFunctionDef = visit_FunctionDef
         node_visitor.visit(ast.parse(code))
         assert expected_names == decorator_names
     return check
@@ -37,6 +38,15 @@ def bar():
     pass
 """
     check_get_decorater_name(code, ['xyz'])
+
+
+def test_get_decorator_name_async(check_get_decorater_name):
+    code = """\
+@foo.bar.route('/foobar')
+async def async_function(request):
+    print(reques)
+"""
+    check_get_decorater_name(code, ['foo.bar.route'])
 
 
 def test_get_decorator_name_multiple_attrs(check_get_decorater_name):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from . import skip_if_not_has_async
 from vulture import utils
 
 
-def check(code, expected_names):
+def check_decorator_names(code, expected_names):
     decorator_names = []
 
     def visit_FunctionDef(node):
@@ -25,7 +25,7 @@ def test_get_decorator_name_simple():
 def hoo():
     pass
 """
-    check(code, ['foobar'])
+    check_decorator_names(code, ['foobar'])
 
 
 def test_get_decorator_name_call():
@@ -34,7 +34,7 @@ def test_get_decorator_name_call():
 def bar():
     pass
 """
-    check(code, ['xyz'])
+    check_decorator_names(code, ['xyz'])
 
 
 @skip_if_not_has_async
@@ -44,7 +44,7 @@ def test_get_decorator_name_async():
 async def async_function(request):
     print(reques)
 """
-    check(code, ['foo.bar.route'])
+    check_decorator_names(code, ['foo.bar.route'])
 
 
 def test_get_decorator_name_multiple_attrs():
@@ -53,7 +53,7 @@ def test_get_decorator_name_multiple_attrs():
 def doo():
     pass
 """
-    check(code, ['x.y.z'])
+    check_decorator_names(code, ['x.y.z'])
 
 
 def test_get_decorator_name_multiple_attrs_called():
@@ -62,7 +62,7 @@ def test_get_decorator_name_multiple_attrs_called():
 def hoofoo():
     pass
 """
-    check(code, ['a.b.c.d.foo'])
+    check_decorator_names(code, ['a.b.c.d.foo'])
 
 
 def test_get_decorator_name_multiple_decorators():
@@ -73,7 +73,7 @@ def test_get_decorator_name_multiple_decorators():
 def func():
     pass
 """
-    check(code, ['foo', 'bar', 'x.y.z.a'])
+    check_decorator_names(code, ['foo', 'bar', 'x.y.z.a'])
 
 
 def test_get_decorator_name_class():
@@ -83,4 +83,4 @@ def test_get_decorator_name_class():
 class Foo:
     pass
 """
-    check(code, ['foo', 'bar.yz'])
+    check_decorator_names(code, ['foo', 'bar.yz'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ def test_get_decorator_name_simple():
 def hoo():
     pass
 """
-    check_decorator_names(code, ['foobar'])
+    check_decorator_names(code, ['@foobar'])
 
 
 def test_get_decorator_name_call():
@@ -34,7 +34,7 @@ def test_get_decorator_name_call():
 def bar():
     pass
 """
-    check_decorator_names(code, ['xyz'])
+    check_decorator_names(code, ['@xyz'])
 
 
 @skip_if_not_has_async
@@ -44,7 +44,7 @@ def test_get_decorator_name_async():
 async def async_function(request):
     print(reques)
 """
-    check_decorator_names(code, ['foo.bar.route'])
+    check_decorator_names(code, ['@foo.bar.route'])
 
 
 def test_get_decorator_name_multiple_attrs():
@@ -53,7 +53,7 @@ def test_get_decorator_name_multiple_attrs():
 def doo():
     pass
 """
-    check_decorator_names(code, ['x.y.z'])
+    check_decorator_names(code, ['@x.y.z'])
 
 
 def test_get_decorator_name_multiple_attrs_called():
@@ -62,7 +62,7 @@ def test_get_decorator_name_multiple_attrs_called():
 def hoofoo():
     pass
 """
-    check_decorator_names(code, ['a.b.c.d.foo'])
+    check_decorator_names(code, ['@a.b.c.d.foo'])
 
 
 def test_get_decorator_name_multiple_decorators():
@@ -73,7 +73,7 @@ def test_get_decorator_name_multiple_decorators():
 def func():
     pass
 """
-    check_decorator_names(code, ['foo', 'bar', 'x.y.z.a'])
+    check_decorator_names(code, ['@foo', '@bar', '@x.y.z.a'])
 
 
 def test_get_decorator_name_class():
@@ -83,4 +83,4 @@ def test_get_decorator_name_class():
 class Foo:
     pass
 """
-    check_decorator_names(code, ['foo', 'bar.yz'])
+    check_decorator_names(code, ['@foo', '@bar.yz'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,76 +1,71 @@
 import ast
 
-import pytest
-
 from . import skip_if_not_has_async
 from vulture import utils
 
 
-@pytest.fixture
-def check_get_decorator_name():
-    def check(code, expected_names):
-        decorator_names = []
+def check(code, expected_names):
+    decorator_names = []
 
-        def visit_FunctionDef(node):
-            for decorator in node.decorator_list:
-                decorator_names.append(utils.get_decorator_name(decorator))
+    def visit_FunctionDef(node):
+        for decorator in node.decorator_list:
+            decorator_names.append(utils.get_decorator_name(decorator))
 
-        node_visitor = ast.NodeVisitor()
-        node_visitor.visit_AsyncFunctionDef = visit_FunctionDef
-        node_visitor.visit_ClassDef = visit_FunctionDef
-        node_visitor.visit_FunctionDef = visit_FunctionDef
-        node_visitor.visit(ast.parse(code))
-        assert expected_names == decorator_names
-    return check
+    node_visitor = ast.NodeVisitor()
+    node_visitor.visit_AsyncFunctionDef = visit_FunctionDef
+    node_visitor.visit_ClassDef = visit_FunctionDef
+    node_visitor.visit_FunctionDef = visit_FunctionDef
+    node_visitor.visit(ast.parse(code))
+    assert expected_names == decorator_names
 
 
-def test_get_decorator_name_simple(check_get_decorator_name):
+def test_get_decorator_name_simple():
     code = """\
 @foobar
 def hoo():
     pass
 """
-    check_get_decorator_name(code, ['foobar'])
+    check(code, ['foobar'])
 
 
-def test_get_decorator_name_call(check_get_decorator_name):
+def test_get_decorator_name_call():
     code = """\
 @xyz()
 def bar():
     pass
 """
-    check_get_decorator_name(code, ['xyz'])
+    check(code, ['xyz'])
 
 
 @skip_if_not_has_async
-def test_get_decorator_name_async(check_get_decorator_name):
+def test_get_decorator_name_async():
     code = """\
 @foo.bar.route('/foobar')
 async def async_function(request):
     print(reques)
 """
-    check_get_decorator_name(code, ['foo.bar.route'])
+    check(code, ['foo.bar.route'])
 
 
-def test_get_decorator_name_multiple_attrs(check_get_decorator_name):
+def test_get_decorator_name_multiple_attrs():
     code = """\
 @x.y.z
 def doo():
     pass
 """
-    check_get_decorator_name(code, ['x.y.z'])
+    check(code, ['x.y.z'])
 
 
-def test_get_decorator_name_multiple_attrs_called(check_get_decorator_name):
+def test_get_decorator_name_multiple_attrs_called():
     code = """\
 @a.b.c.d.foo("Foo and Bar")
 def hoofoo():
     pass
 """
-    check_get_decorator_name(code, ['a.b.c.d.foo'])
+    check(code, ['a.b.c.d.foo'])
 
 
-def test_get_decorator_name_multiple_decorators(check_get_decorator_name):
+def test_get_decorator_name_multiple_decorators():
     code = """\
 @foo
 @bar()
@@ -78,14 +73,14 @@ def test_get_decorator_name_multiple_decorators(check_get_decorator_name):
 def func():
     pass
 """
-    check_get_decorator_name(code, ['foo', 'bar', 'x.y.z.a'])
+    check(code, ['foo', 'bar', 'x.y.z.a'])
 
 
-def test_get_decorator_name_class(check_get_decorator_name):
+def test_get_decorator_name_class():
     code = """\
 @foo
 @bar.yz
 class Foo:
     pass
 """
-    check_get_decorator_name(code, ['foo', 'bar.yz'])
+    check(code, ['foo', 'bar.yz'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+import ast
+
+import pytest
+
+from vulture import utils
+
+
+@pytest.fixture
+def check_get_decorater_name():
+    def check(code, expected_names):
+        decorator_names = []
+
+        def visit_FunctionDef(node):
+            for decorator in node.decorator_list:
+                decorator_names.append(utils.get_decorator_name(decorator))
+
+        node_visitor = ast.NodeVisitor()
+        node_visitor.visit_FunctionDef = visit_FunctionDef
+        node_visitor.visit(ast.parse(code))
+        assert expected_names == decorator_names
+    return check
+
+
+def test_get_decorator_name(check_get_decorater_name):
+    code = """\
+@foobar
+def hoo():
+    pass
+
+@xyz()
+def bar():
+    pass
+
+@x.y.z
+def doo():
+    pass
+
+@a.b.c.d.foo("Foo and Bar")
+def hoofoo():
+    pass
+"""
+    check_get_decorater_name(code, ['foobar', 'xyz', 'x.y.z', 'a.b.c.d.foo'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import ast
 
 import pytest
 
+from . import skip_if_not_has_async
 from vulture import utils
 
 
@@ -41,6 +42,7 @@ def bar():
     check_get_decorator_name(code, ['xyz'])
 
 
+@skip_if_not_has_async
 def test_get_decorator_name_async(check_get_decorator_name):
     code = """\
 @foo.bar.route('/foobar')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from vulture import utils
 
 
 @pytest.fixture
-def check_get_decorater_name():
+def check_get_decorator_name():
     def check(code, expected_names):
         decorator_names = []
 
@@ -15,53 +15,75 @@ def check_get_decorater_name():
                 decorator_names.append(utils.get_decorator_name(decorator))
 
         node_visitor = ast.NodeVisitor()
-        node_visitor.visit_FunctionDef = visit_FunctionDef
         node_visitor.visit_AsyncFunctionDef = visit_FunctionDef
+        node_visitor.visit_ClassDef = visit_FunctionDef
+        node_visitor.visit_FunctionDef = visit_FunctionDef
         node_visitor.visit(ast.parse(code))
         assert expected_names == decorator_names
     return check
 
 
-def test_get_decorator_name_simple(check_get_decorater_name):
+def test_get_decorator_name_simple(check_get_decorator_name):
     code = """\
 @foobar
 def hoo():
     pass
 """
-    check_get_decorater_name(code, ['foobar'])
+    check_get_decorator_name(code, ['foobar'])
 
 
-def test_get_decorator_name_call(check_get_decorater_name):
+def test_get_decorator_name_call(check_get_decorator_name):
     code = """\
 @xyz()
 def bar():
     pass
 """
-    check_get_decorater_name(code, ['xyz'])
+    check_get_decorator_name(code, ['xyz'])
 
 
-def test_get_decorator_name_async(check_get_decorater_name):
+def test_get_decorator_name_async(check_get_decorator_name):
     code = """\
 @foo.bar.route('/foobar')
 async def async_function(request):
     print(reques)
 """
-    check_get_decorater_name(code, ['foo.bar.route'])
+    check_get_decorator_name(code, ['foo.bar.route'])
 
 
-def test_get_decorator_name_multiple_attrs(check_get_decorater_name):
+def test_get_decorator_name_multiple_attrs(check_get_decorator_name):
     code = """\
 @x.y.z
 def doo():
     pass
 """
-    check_get_decorater_name(code, ['x.y.z'])
+    check_get_decorator_name(code, ['x.y.z'])
 
 
-def test_get_decorator_name_multiple_attrs_called(check_get_decorater_name):
+def test_get_decorator_name_multiple_attrs_called(check_get_decorator_name):
     code = """\
 @a.b.c.d.foo("Foo and Bar")
 def hoofoo():
     pass
 """
-    check_get_decorater_name(code, ['a.b.c.d.foo'])
+    check_get_decorator_name(code, ['a.b.c.d.foo'])
+
+
+def test_get_decorator_name_multiple_decorators(check_get_decorator_name):
+    code = """\
+@foo
+@bar()
+@x.y.z.a('foobar')
+def func():
+    pass
+"""
+    check_get_decorator_name(code, ['foo', 'bar', 'x.y.z.a'])
+
+
+def test_get_decorator_name_class(check_get_decorator_name):
+    code = """\
+@foo
+@bar.yz
+class Foo:
+    pass
+"""
+    check_get_decorator_name(code, ['foo', 'bar.yz'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,22 +21,37 @@ def check_get_decorater_name():
     return check
 
 
-def test_get_decorator_name(check_get_decorater_name):
+def test_get_decorator_name_simple(check_get_decorater_name):
     code = """\
 @foobar
 def hoo():
     pass
+"""
+    check_get_decorater_name(code, ['foobar'])
 
+
+def test_get_decorator_name_call(check_get_decorater_name):
+    code = """\
 @xyz()
 def bar():
     pass
+"""
+    check_get_decorater_name(code, ['xyz'])
 
+
+def test_get_decorator_name_multiple_attrs(check_get_decorater_name):
+    code = """\
 @x.y.z
 def doo():
     pass
+"""
+    check_get_decorater_name(code, ['x.y.z'])
 
+
+def test_get_decorator_name_multiple_attrs_called(check_get_decorater_name):
+    code = """\
 @a.b.c.d.foo("Foo and Bar")
 def hoofoo():
     pass
 """
-    check_get_decorater_name(code, ['foobar', 'xyz', 'x.y.z', 'a.b.c.d.foo'])
+    check_get_decorater_name(code, ['a.b.c.d.foo'])

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -170,8 +170,7 @@ class Vulture(ast.NodeVisitor):
         self.ignore_names = ignore_names or []
         self.ignore_decorators = ignore_decorators or []
         self.ignore_decorators = [
-            decor[1:] if decor.startswith('@') else decor
-            for decor in self.ignore_decorators]
+            decorator.lstrip('@') for decorator in self.ignore_decorators]
 
         self.filename = ''
         self.code = []

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -51,8 +51,6 @@ IGNORED_VARIABLE_NAMES = set(['object', 'self'])
 if sys.version_info < (3, 4):
     IGNORED_VARIABLE_NAMES |= set(['True', 'False'])
 
-UNSAFE_IGNORE_NAMES = ['property']
-
 
 def _get_unused_items(defined_items, used_names):
     unused_items = [item for item in set(defined_items)
@@ -380,41 +378,26 @@ class Vulture(ast.NodeVisitor):
         return self.visit_FunctionDef(node)
 
     def visit_Attribute(self, node):
-        if self.ignored(node.attr):
-            self._log('Ignoring Attribute "{}" (ignored name)'.format(
-                node.attr))
-            return
         if isinstance(node.ctx, ast.Store):
             self._define(self.defined_attrs, node.attr, node)
         elif isinstance(node.ctx, ast.Load):
             self.used_attrs.add(node.attr)
 
     def visit_ClassDef(self, node):
-        if self.ignored(node.name):
-            self._log('Ignoring class "{}" (ignored name)'.format(node.name))
-            return
         self._define(
             self.defined_classes, node.name, node, ignore=_ignore_class)
 
     def visit_FunctionDef(self, node):
         for decorator in node.decorator_list:
-            n = decorator.func if isinstance(
+            decorator = decorator.func if isinstance(
                 decorator, ast.Call) else decorator
-            name = n.attr if isinstance(n, ast.Attribute) else n.id
-            if self.ignored(name):
-                self._log(
-                    'Ignoring function "{}" (ignored decorator: "{}")'.format(
-                        node.name, name))
-                break
-            elif name == 'property':
+            name = decorator.attr if isinstance(
+                decorator, ast.Attribute) else decorator.id
+            if name == 'property':
                 self._define(self.defined_props, node.name, node)
                 break
         else:
             # Function is not a property.
-            if self.ignored(node.name):
-                self._log('Ignoring function "{}" (ignored name)'.format(
-                    node.name))
-                return
             self._define(
                 self.defined_funcs, node.name, node,
                 ignore=_ignore_function)

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -169,8 +169,6 @@ class Vulture(ast.NodeVisitor):
 
         self.ignore_names = ignore_names or []
         self.ignore_decorators = ignore_decorators or []
-        self.ignore_decorators = [
-            decorator.lstrip('@') for decorator in self.ignore_decorators]
 
         self.filename = ''
         self.code = []
@@ -403,7 +401,7 @@ class Vulture(ast.NodeVisitor):
     def visit_FunctionDef(self, node):
         decorator_names = [utils.get_decorator_name(
             decorator) for decorator in node.decorator_list]
-        typ = 'property' if 'property' in decorator_names else 'function'
+        typ = 'property' if '@property' in decorator_names else 'function'
         if any(_match(name, self.ignore_decorators)
                for name in decorator_names):
             self._log('Ignoring {} "{}" (decorator whitelisted)'.format(

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -525,10 +525,6 @@ def _parse_args():
         help='Comma-separated list of names to ignore (e.g., "visit_*,do_*").'
         ' {glob_help}'.format(**locals()))
     parser.add_argument(
-        '--make-whitelist', action='store_true',
-        help='Report unused code in a format that can be added to a'
-        ' whitelist module.')
-    parser.add_argument(
         '--min-confidence', type=int, default=0,
         help='Minimum confidence (between 0 and 100) for code to be'
         ' reported as unused.')

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -531,9 +531,9 @@ def _parse_args():
         help='Comma-separated list of names to ignore (e.g., "visit_*,do_*").'
         ' {glob_help}'.format(**locals()))
     parser.add_argument(
-            '--make-whitelist', action='store_true',
-            help='Report unused code in a format that can be added to a'
-            ' whitelist module.')
+        '--make-whitelist', action='store_true',
+        help='Report unused code in a format that can be added to a'
+        ' whitelist module.')
     parser.add_argument(
         '--min-confidence', type=int, default=0,
         help='Minimum confidence (between 0 and 100) for code to be'

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -389,19 +389,8 @@ class Vulture(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         for decorator in node.decorator_list:
-            if isinstance(decorator, ast.Call):
-                decorator = decorator.func
-            if isinstance(decorator, ast.Attribute):
-                name = decorator.attr
-            else:
-                name = decorator.id
-            if name == 'property':
+            if getattr(decorator, 'id', None) == 'property':
                 self._define(self.defined_props, node.name, node)
-                break
-            elif self._ignore_name(name):
-                self._log(
-                    'Ignoring function "{}" (decorator whitelisted)'.format(
-                        node.name))
                 break
         else:
             # Function is not a property.

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -389,8 +389,14 @@ class Vulture(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         for decorator in node.decorator_list:
-            if getattr(decorator, 'id', None) == 'property':
+            name = utils.get_decorator_name(decorator)
+            if name == 'property':
                 self._define(self.defined_props, node.name, node)
+                break
+            elif self._ignore_name('@' + name):
+                self._log(
+                    'Ignoring function "{}" (decorator whitelisted)'.format(
+                        node.name))
                 break
         else:
             # Function is not a property.

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -403,13 +403,13 @@ class Vulture(ast.NodeVisitor):
     def visit_FunctionDef(self, node):
         for decorator in node.decorator_list:
             name = utils.get_decorator_name(decorator)
-            if name == 'property':
-                self._define(self.defined_props, node.name, node)
-                break
-            elif _match(name, self.ignore_decorators):
+            if _match(name, self.ignore_decorators):
                 self._log(
-                    'Ignoring function "{}" (decorator whitelisted)'.format(
-                        node.name))
+                    'Ignoring {} "{}" (decorator whitelisted)'.format(
+                        name if name == 'property' else 'function', node.name))
+                break
+            elif name == 'property':
+                self._define(self.defined_props, node.name, node)
                 break
         else:
             # Function is not a property.

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -531,6 +531,10 @@ def _parse_args():
         help='Comma-separated list of names to ignore (e.g., "visit_*,do_*").'
         ' {glob_help}'.format(**locals()))
     parser.add_argument(
+            '--make-whitelist', action='store_true',
+            help='Report unused code in a format that can be added to a'
+            ' whitelist module.')
+    parser.add_argument(
         '--min-confidence', type=int, default=0,
         help='Minimum confidence (between 0 and 100) for code to be'
         ' reported as unused.')

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -354,11 +354,10 @@ class Vulture(ast.NodeVisitor):
 
     def _define(self, collection, name, first_node, last_node=None,
                 message='', confidence=DEFAULT_CONFIDENCE, ignore=None):
-        def _ignore_name(name):
-            return _match(name, self.ignore_names)
         last_node = last_node or first_node
         typ = collection.typ
-        if (ignore and ignore(self.filename, name)) or _ignore_name(name):
+        if (ignore and ignore(self.filename, name)) or _match(
+                name, self.ignore_names):
             self._log('Ignoring {typ} "{name}"'.format(**locals()))
         else:
             first_lineno = first_node.lineno
@@ -393,14 +392,12 @@ class Vulture(ast.NodeVisitor):
             self.defined_classes, node.name, node, ignore=_ignore_class)
 
     def visit_FunctionDef(self, node):
-        def _ignore_decorator(name):
-            return _match(name, self.ignore_decorators)
         for decorator in node.decorator_list:
             name = utils.get_decorator_name(decorator)
             if name == 'property':
                 self._define(self.defined_props, node.name, node)
                 break
-            elif _ignore_decorator(name):
+            elif _match(name, self.ignore_decorators):
                 self._log(
                     'Ignoring function "{}" (decorator whitelisted)'.format(
                         node.name))

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -389,12 +389,19 @@ class Vulture(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         for decorator in node.decorator_list:
-            decorator = decorator.func if isinstance(
-                decorator, ast.Call) else decorator
-            name = decorator.attr if isinstance(
-                decorator, ast.Attribute) else decorator.id
+            if isinstance(decorator, ast.Call):
+                decorator = decorator.func
+            if isinstance(decorator, ast.Attribute):
+                name = decorator.attr
+            else:
+                name = decorator.id
             if name == 'property':
                 self._define(self.defined_props, node.name, node)
+                break
+            elif self._ignore_name(name):
+                self._log(
+                    'Ignoring function "{}" (decorator whitelisted)'.format(
+                        node.name))
                 break
         else:
             # Function is not a property.

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -56,6 +56,18 @@ def format_path(path):
     return relpath if not relpath.startswith('..') else path
 
 
+def get_decorator_name(decorator):
+    name = ''
+    if isinstance(decorator, ast.Call):
+        decorator = decorator.func
+    while isinstance(decorator, ast.Attribute):
+        name = decorator.attr + ('.' + name if name else '')
+        decorator = decorator.value
+    else:
+        name = decorator.id + ('.' + name if name else '')
+    return name
+
+
 def get_modules(paths, toplevel=True):
     """Take files from the command line even if they don't end with .py."""
     modules = []

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -57,15 +57,14 @@ def format_path(path):
 
 
 def get_decorator_name(decorator):
-    parts = []
     if isinstance(decorator, ast.Call):
         decorator = decorator.func
+    parts = []
     while isinstance(decorator, ast.Attribute):
         parts.append(decorator.attr)
         decorator = decorator.value
     parts.append(decorator.id)
-    parts.reverse()
-    return ".".join(parts)
+    return '.'.join(reversed(parts))
 
 
 def get_modules(paths, toplevel=True):

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -57,15 +57,15 @@ def format_path(path):
 
 
 def get_decorator_name(decorator):
-    name = ''
+    parts = []
     if isinstance(decorator, ast.Call):
         decorator = decorator.func
     while isinstance(decorator, ast.Attribute):
-        name = decorator.attr + ('.' + name if name else '')
+        parts.append(decorator.attr)
         decorator = decorator.value
-    else:
-        name = decorator.id + ('.' + name if name else '')
-    return name
+    parts.append(decorator.id)
+    parts.reverse()
+    return ".".join(parts)
 
 
 def get_modules(paths, toplevel=True):

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -64,7 +64,7 @@ def get_decorator_name(decorator):
         parts.append(decorator.attr)
         decorator = decorator.value
     parts.append(decorator.id)
-    return '.'.join(reversed(parts))
+    return '@' + '.'.join(reversed(parts))
 
 
 def get_modules(paths, toplevel=True):


### PR DESCRIPTION
Currently, the ``--ignore-names`` flag only ignores names of entities whose names matches with the given input. After this PR is merged, users would be able to ignore functions on the basis of their decorators. For example, `vulture myproject.py --ignore-names "@app.route"` ignores all the functions which are decorated with `app.route`.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation in the README file.
- [X] I have updated the documentation accordingly.
- [X] I have added an entry in NEWS.rst.
- [X] I have added tests to cover my changes.
- [x] Add tests for `get_decorator_name`
- [X] All new and existing tests passed.
