### PR TITLE
Use Item.get_whitelist_string.

### DIFF
--- a/tests/test_make_whitelist.py
+++ b/tests/test_make_whitelist.py
@@ -9,9 +9,8 @@ def check_whitelist(v):
     def examine(code, results_before, results_after):
         v.scan(code)
         check(v.get_unused_code(), results_before)
-        whitelist = [item.get_whitelist_string() for item in v.get_unused_code()]
-        for whitelist_string in whitelist:
-            v.scan(whitelist_string)
+        for item in v.get_unused_code():
+            v.scan(item.get_whitelist_string())
         check(v.get_unused_code(), results_after)
     return examine
 

--- a/tests/test_make_whitelist.py
+++ b/tests/test_make_whitelist.py
@@ -5,14 +5,13 @@ assert v  # silence pyflakes
 
 
 @pytest.fixture
-def check_whitelist(v, capsys):
+def check_whitelist(v):
     def examine(code, results_before, results_after):
         v.scan(code)
         check(v.get_unused_code(), results_before)
-        capsys.readouterr()  # Clear captured text
-        v.make_whitelist()
-        whitelist = capsys.readouterr().out
-        v.scan(whitelist)
+        whitelist = [item.get_whitelist_string() for item in v.get_unused_code()]
+        for whitelist_string in whitelist:
+            v.scan(whitelist_string)
         check(v.get_unused_code(), results_after)
     return examine
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -53,7 +53,7 @@ Foo  # unused class ({filename}:3)
 bar  # unused function ({filename}:7)
 _.foobar  # unused attribute ({filename}:8)
 foobar  # unused variable ({filename}:9)
-# unreachable code after 'return' in file {filename} at line 11
+# unreachable code after 'return' ({filename}:11)
 _.myprop  # unused property ({filename}:13)
 """
     check_report(mock_code, expected, make_whitelist=True)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -27,9 +27,8 @@ def check_report(v, capsys):
     def test_report(code, expected,  make_whitelist=False):
         filename = 'foo.py'
         v.scan(code, filename=filename)
-        report_func = v.make_whitelist if make_whitelist else v.report
         capsys.readouterr()
-        report_func()
+        v.report(make_whitelist=make_whitelist)
         assert capsys.readouterr().out == expected.format(filename=filename)
     return test_report
 
@@ -54,6 +53,7 @@ Foo  # unused class ({filename}:3)
 bar  # unused function ({filename}:7)
 _.foobar  # unused attribute ({filename}:8)
 foobar  # unused variable ({filename}:9)
+# unreachable code after 'return' in file {filename} at line 11
 _.myprop  # unused property ({filename}:13)
 """
     check_report(mock_code, expected, make_whitelist=True)

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -131,12 +131,14 @@ class Item(object):
             self.message, self.confidence, size_report)
 
     def get_whitelist_string(self):
-        if self.typ != 'unreachable_code':
+        if self.typ == 'unreachable_code':
+            return ('# {message} in file {filename} at line'
+                    ' {first_lineno}'.format(**self.__dict__))
+        else:
             prefix = '_.' if self.typ in ['attribute', 'property'] else ''
             return "{}{}  # unused {} ({}:{:d})".format(
                     prefix, self.name, self.typ,
                     utils.format_path(self.filename), self.first_lineno)
-        return ''
 
     def _tuple(self):
         return (self.filename, self.first_lineno, self.name)
@@ -277,9 +279,8 @@ class Vulture(ast.NodeVisitor):
         """
         for item in self.get_unused_code(
                 min_confidence=min_confidence, sort_by_size=sort_by_size):
-            report = (item.get_whitelist_string() if make_whitelist
-                      else item.get_report(add_size=sort_by_size))
-            print(report)
+            print(item.get_whitelist_string() if make_whitelist
+                  else item.get_report(add_size=sort_by_size))
             self.found_dead_code_or_error = True
         return self.found_dead_code_or_error
 

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -131,14 +131,14 @@ class Item(object):
             self.message, self.confidence, size_report)
 
     def get_whitelist_string(self):
+        filename = utils.format_path(self.filename)
         if self.typ == 'unreachable_code':
-            return ('# {message} in file {filename} at line'
-                    ' {first_lineno}'.format(**self.__dict__))
+            return ('# {} ({}:{})'.format(
+                self.message, filename, self.first_lineno))
         else:
             prefix = '_.' if self.typ in ['attribute', 'property'] else ''
             return "{}{}  # unused {} ({}:{:d})".format(
-                    prefix, self.name, self.typ,
-                    utils.format_path(self.filename), self.first_lineno)
+                    prefix, self.name, self.typ, filename, self.first_lineno)
 
     def _tuple(self):
         return (self.filename, self.first_lineno, self.name)


### PR DESCRIPTION
## Description

Use `Item.get_whitelist_string` to create a message string.  This was previously implemented using `make_whitelist`, but that was redundant and also prevented whitelist functionality to be a part of the Vulture API.

## Related Issue

Closes: #143 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
