### PR TITLE
.travis.yml: Test on py37, py38-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,26 @@
 language: python
-python:
-- pypy
-- pypy3
-- '2.7'
-- '3.4'
-- '3.5'
-- '3.6'
-- 3.7-dev
 
 matrix:
+  include:
+  - python: pypy
+  - python: pypy3
+  - python: '2.7'
+  - python: '3.4'
+  - python: '3.5'
+  - python: '3.6'
+  - python: '3.7'
+    dist: xenial
+    sudo: true
+  - python: 3.8-dev
+    dist: xenial
+    sudo: true
   fast_finish: true
   allow_failures:
-  - python: 3.7-dev
+  - python: 3.8-dev
 install:
   - pip install tox coveralls
   - python setup.py bdist_wheel
-  - pip install --use-wheel ./dist/vulture-*.whl
+  - "pip install --only-binary=:all: ./dist/vulture-*.whl"
 script:
   # Run the installed version of vulture on local code.
   - vulture vulture/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cleanup, docs, py27, py34, py35, py36, style
+envlist = cleanup, docs, py27, py34, py35, py36, py37, style
 skip_missing_interpreters = true
 
 # Erase old coverage results, then accumulate them during this tox run.


### PR DESCRIPTION
## Description

Increase support for Python3.7 and also test for py38 (allowed failures). Also, switch to `--only-binary` instead of using `--use-wheel` which has been deprecated since pip7 and removed in pip10 beta-1


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
