### PR TITLE
Add whitelist for the threading module

### DIFF
--- a/vulture/whitelists/threading_whitelist.py
+++ b/vulture/whitelists/threading_whitelist.py
@@ -1,5 +1,5 @@
 import threading
 
-threading.Thread.name
 threading.Thread.daemon
+threading.Thread.name
 threading.Thread.run

--- a/vulture/whitelists/threading_whitelist.py
+++ b/vulture/whitelists/threading_whitelist.py
@@ -1,0 +1,5 @@
+import threading
+
+threading.Thread.name
+threading.Thread.daemon
+threading.Thread.run


### PR DESCRIPTION
## Description
When subclassing threading.Thread, make sure Thread.name, Thread.daemon, and Thread.run don't get marked as unused.

## Related Issue
#147 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
