### PR TITLE
Ignore type checking imports

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -5,6 +5,7 @@ News
 ----------------
 * Add ``sys.excepthook`` to ``sys`` whitelist.
 * Add whitelist for ``ctypes`` module.
+* Add test to check that ``typing`` module imports are marked as used
 
 
 1.0 (2018-10-23)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -5,7 +5,7 @@ News
 ----------------
 * Add ``sys.excepthook`` to ``sys`` whitelist.
 * Add whitelist for ``ctypes`` module.
-* Add test to check that ``typing`` module imports are marked as used
+* Check that Python 3.6 type-annotations are parsed and type comments are ignored (thanks @kx-chen).
 
 
 1.0 (2018-10-23)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add type checking imports from `typing` to whitelist. 

File named as `typing_whitelist.py`, as it seems the code looks for those files, and it matches the other file names.

Added a `try` block around the importing, as sometimes `typing` is not always available. 

I got the types from https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html and https://docs.python.org/3/library/typing.html. Please advise if I've missed any or need any changes.

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, please link to it here: -->
https://github.com/jendrikseipp/vulture/issues/152

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
