### PR TITLE
Drop support for Python 3.4 because it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
   - python: pypy
   - python: pypy3
   - python: '2.7'
-  - python: '3.4'
   - python: '3.5'
   - python: '3.6'
   - python: '3.7'

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Features
 * tested: tests itself and has complete test coverage
 * complements pyflakes and has the same output syntax
 * sorts unused classes and functions by size with ``--sort-by-size``
-* supports Python 2.7 and Python >= 3.4
+* supports Python 2.7 and Python >= 3.5
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ setuptools.setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Quality Assurance'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cleanup, docs, py27, py34, py35, py36, py37, style
+envlist = cleanup, docs, py27, py35, py36, py37, style
 skip_missing_interpreters = true
 
 # Erase old coverage results, then accumulate them during this tox run.
@@ -22,5 +22,5 @@ deps =
 commands = python setup.py checkdocs
 
 [testenv:style]
-deps = flake8==3.6.0
+deps = flake8==3.7.7
 commands = flake8 --extend-ignore=F841 setup.py tests/ vulture/  # Ignore false-positive.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Modify four files to Drop support for the EOLed Python 3.4
* Upgrade to a current version of flake8
## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, please link to it here: -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation in the README file.
- [x] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
