### PR TITLE
Speedup creating Item objects

### DIFF
--- a/vulture/core.py
+++ b/vulture/core.py
@@ -102,6 +102,8 @@ class Item(object):
     """
     Hold the name, type and location of defined code.
     """
+    __slots__ = ('name', 'typ', 'filename', 'first_lineno',
+                 'last_lineno', 'message', 'confidence')
 
     def __init__(self, name, typ, filename, first_lineno, last_lineno,
                  message='',


### PR DESCRIPTION
According to vmprof (https://github.com/vmprof/vmprof-python) over
a large code base, about 20% of the time was spent in Item:__init__,
use slots to reduce the time spent in Item:__init__ to 1%

```import timeit


class Foo(object):
    def __init__(self):
        self.a = 1
        self.b = 2
        self.c = 3
        self.d = 4
        self.e = 5
        self.f = 6
        self.g = 7


class Bar(object):
    __slots__ = ('a', 'b', 'c', 'd', 'e', 'f', 'g')


print(timeit.timeit('Foo()', 'from __main__ import Foo'))
print(timeit.timeit('Bar()', 'from __main__ import Bar'))
```

```
0.796907901764
0.0809969902039
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
