### PR TITLE
Fix Windows Build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,21 @@
 version: 1.0.{build}
 
+environment:
+  matrix:
+  - TOXENV: cleanup
+  - TOXENV: docs
+  - TOXENV: py27
+    PYTHON: "C:\\Python27-x64"
+  - TOXENV: py35
+    PYTHON: "C:\\Python35-x64"
+  - TOXENV: py36
+    PYTHON: "C:\\Python36-x64"
+  - TOXENV: py37
+    PYTHON: "C:\\Python37-x64"
+  - TOXENV: style
+
 install:
-- cmd: python -m pip install -U pip setuptools tox wheel
+- cmd: python -m pip install -U pip setuptools tox wheel virtualenv
 
 build_script:
 - cmd: python setup.py bdist_wheel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   - TOXENV: style
 
 install:
-- cmd: python -m pip install -U pip setuptools tox wheel virtualenv
+- cmd: python -m pip install -U pip setuptools tox virtualenv wheel
 
 build_script:
 - cmd: python setup.py bdist_wheel


### PR DESCRIPTION
## Description

Previously, pip was too old and did not understand pip's metadata. Updating virtualenv before running tests solves this problem.

Also, add tox environments to Appveyor (as recommended on [their website][appv]).

[appv]: https://www.appveyor.com/docs/lang/python/

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, please link to it here: -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [x] I have updated the documentation accordingly.
- [ ] I have added an entry in NEWS.rst.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
