### PR TITLE
Add whitelist for string.Formatter

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,6 +4,7 @@ News
 1.3 (unreleased)
 ----------------
 * Detect redundant 'if' conditions without 'else' blocks.
+* Add whitelist for ``string.Formatter`` (#183).
 
 
 1.2 (2019-11-22)

--- a/vulture/whitelists/string_whitelist.py
+++ b/vulture/whitelists/string_whitelist.py
@@ -1,0 +1,10 @@
+import string
+
+string.Formatter.check_unused_args
+string.Formatter.convert_field
+string.Formatter.format
+string.Formatter.format_field
+string.Formatter.get_field
+string.Formatter.get_value
+string.Formatter.parse
+string.Formatter.vformat


### PR DESCRIPTION
## Description
Vulture can mistake methods of child classes of `string.Formatter` as unused.  Add a whitelist to deal with this.

## Related Issue
#183 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry in NEWS.rst.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (py27 blew up locally with a `CoverageException`, and I can't install 3.5)
