### PR TITLE
Ignore results annotated with '# noqa'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Report issue codes in ouput (e.g., `code.py:1: V104 unused import ...`)
+  (RJ722, #195)
+* Support `# noqa` comments to suppress results on that line. (RJ722, #195).
+
 # 1.4 (2020-03-30)
 
 * Ignore unused import statements in `__init__.py` (RJ722, #192).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Report issue codes in ouput (e.g., `code.py:1: V104 unused import ...`)
+* Report issue codes in output (e.g., `code.py:1: V104 unused import ...`)
   (RJ722, #195)
 * Support `# noqa` comments to suppress results on that line. (RJ722, #195).
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ We collect whitelists for common Python modules and packages in
 a whole file or directory, use the `--exclude` parameter (e.g.,
 `--exclude *settings.py,docs/`).
 
-The other, more common way of ignoring results is to annotate the line causing
-the false positive with `# noqa <ERROR_CODE>` in a trailing comment.
+Another way of ignoring errors is to annotate the line causing the false 
+positive with `# noqa: <ERROR_CODE>` in a trailing comment (e.g., 
+`# noqa: V103`).
 
 The `ERROR_CODE` specifies what kind of dead code to ignore (see the table
-below for details). In case no error code is specified, Vulture ignores all
-results for the line.
+below for the list of error codes). In case no error code is specified, 
+Vulture ignores all results for the line.
 
 Note that the line number for any decorated object is the same as the line
 number of the first decorator.
@@ -175,33 +176,24 @@ makes Vulture ignore the `greet` method:
 **Using "# noqa"**
 
 ```python
-import os
+import os  # noqa
 
-class Greeter:
+class Greeter:  # noqa: 102
     def greet(self):  # noqa: V103
         print("Hi")
-
-def hello_world():
-    message = "Hello, world!"
-    greeter = Greeter()
-    greet_func = getattr(greeter, "greet")
-    greet_func()
-
-if __name__ == "__main__":
-    hello_world()
 ```
 
 ## Error codes
 
-| Error Code |    Description    |
+| Error code |    Description    |
 | ---------- | ----------------- |
-|    V101    | Unused Attribute  |
-|    V102    | Unused Class      |
-|    V103    | Unused Function   |
-|    V104    | Unused Import     |
-|    V105    | Unused Property   |
-|    V106    | Unused Variable   |
-|    V201    | Unreachable Code  |
+|    V101    | Unused attribute  |
+|    V102    | Unused class      |
+|    V103    | Unused function   |
+|    V104    | Unused import     |
+|    V105    | Unused property   |
+|    V106    | Unused variable   |
+|    V201    | Unreachable code  |
 
 ## Exit codes
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ tool for higher code quality.
 * tested: tests itself and has complete test coverage
 * complements pyflakes and has the same output syntax
 * sorts unused classes and functions by size with `--sort-by-size`
+* respects `# noqa` comments
 * supports Python 2.7 and Python \>= 3.5
 
 ## Installation
@@ -57,6 +58,16 @@ We collect whitelists for common Python modules and packages in
 `vulture/whitelists/` (pull requests are welcome). If you want to ignore
 a whole file or directory, use the `--exclude` parameter (e.g.,
 `--exclude *settings.py,docs/`).
+
+The other, more common way of ignoring results is to annotate the line causing
+the false positive with `# noqa <ERROR_CODE>` in a trailing comment.
+
+The `ERROR_CODE` specifies what kind of dead code to ignore (see the table
+below for details). In case no error code is specified, Vulture ignores all
+results for the line.
+
+Note that the line number for any decorated object is the same as the line
+number of the first decorator.
 
 **Ignoring names**
 
@@ -130,9 +141,9 @@ Calling :
 
 results in the following output:
 
-    dead_code.py:1: unused import 'os' (90% confidence)
-    dead_code.py:4: unused function 'greet' (60% confidence)
-    dead_code.py:8: unused variable 'message' (60% confidence)
+    dead_code.py:1: V104 unused import 'os' (90% confidence)
+    dead_code.py:4: V103 unused function 'greet' (60% confidence)
+    dead_code.py:8: V106 unused variable 'message' (60% confidence)
 
 Vulture correctly reports "os" and "message" as unused, but it fails to
 detect that "greet" is actually used. The recommended method to deal
@@ -158,8 +169,39 @@ Passing both the original program and the whitelist to Vulture
 
 makes Vulture ignore the `greet` method:
 
-    dead_code.py:1: unused import 'os' (90% confidence)
-    dead_code.py:8: unused variable 'message' (60% confidence)
+    dead_code.py:1: V104 unused import 'os' (90% confidence)
+    dead_code.py:8: V106 unused variable 'message' (60% confidence)
+
+**Using "# noqa"**
+
+```python
+import os
+
+class Greeter:
+    def greet(self):  # noqa: V103
+        print("Hi")
+
+def hello_world():
+    message = "Hello, world!"
+    greeter = Greeter()
+    greet_func = getattr(greeter, "greet")
+    greet_func()
+
+if __name__ == "__main__":
+    hello_world()
+```
+
+## Error codes
+
+| Error Code |    Description    |
+| ---------- | ----------------- |
+|    V101    | Unused Attribute  |
+|    V102    | Unused Class      |
+|    V103    | Unused Function   |
+|    V104    | Unused Import     |
+|    V105    | Unused Property   |
+|    V106    | Unused Variable   |
+|    V201    | Unreachable Code  |
 
 ## Exit codes
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ We collect whitelists for common Python modules and packages in
 a whole file or directory, use the `--exclude` parameter (e.g.,
 `--exclude *settings.py,docs/`).
 
-Another way of ignoring errors is to annotate the line causing the false 
-positive with `# noqa: <ERROR_CODE>` in a trailing comment (e.g., 
+Another way of ignoring errors is to annotate the line causing the false
+positive with `# noqa: <ERROR_CODE>` in a trailing comment (e.g.,
 `# noqa: V103`).
 
 The `ERROR_CODE` specifies what kind of dead code to ignore (see the table
-below for the list of error codes). In case no error code is specified, 
+below for the list of error codes). In case no error code is specified,
 Vulture ignores all results for the line.
 
 Note that the line number for any decorated object is the same as the line

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vulture.core import NOQA_REGEXP, _parse_error_codes
+from vulture.noqa import NOQA_REGEXP, parse_error_codes
 from . import check, v
 
 assert v  # Silence pyflakes.
@@ -19,7 +19,7 @@ assert v  # Silence pyflakes.
 )
 def test_noqa_regex_present(line, codes):
     match = NOQA_REGEXP.search(line)
-    parsed = _parse_error_codes(match)
+    parsed = parse_error_codes(match)
     assert parsed == codes
 
 

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -150,30 +150,55 @@ import dis  # noqa: V001 (code for unused attr)
     check(v.unused_imports, ["foo", "zoo", "dis"])
 
 
-def test_noqa_propoerties(v):
+def test_noqa_properties(v):
     v.scan(
         """\
 class Zoo:
-    @property  # noqa
-    def no_of_coalas(self):
-        pass
-
-    @property  # noqa: V005
-    def area(self, width, depth):  
+    @property
+    def no_of_coalas(self):  # noqa
         pass
 
     @property
-    def entry_gates(self):  # noqa
+    def area(self, width, depth):  # noqa: V005
         pass
 
-    @property  # noqa: V003 (code for unused function)
-    def tickets(self):
+    @property  # noqa  (should not be ignored)
+    def entry_gates(self):
+        pass
+
+    @property  
+    def tickets(self):  # noqa: V003 (code for unused function)
         pass
 """
     )
     check(v.unused_props, ["entry_gates", "tickets"])
     check(v.unused_classes, ["Zoo"])
     check(v.unused_vars, ["width", "depth"])
+
+
+def test_noqa_properties_multiple_decorators(v):
+    v.scan(
+        """\
+class Foo:
+    @property
+    @make_it_cool
+    @log
+    def something(self):  # noqa: V005
+        pass
+
+    @coolify
+    @property
+    def something_else(self):  # noqa: V005
+        pass
+
+    @a
+    @property
+    @b  # noqa
+    def abcd(self):
+        pass
+"""
+    )
+    check(v.unused_props, ['abcd'])
 
 
 def test_noqa_unreacahble_code(v):

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -30,15 +30,15 @@ def test_noqa_regex_present(line, codes):
     [("# noqa: 123V"), ("# noqa explaination: V012"), ("# noqa: ,V001"),],
 )
 def test_noqa_regex_no_groups(line):
-    assert NOQA_REGEXP.search(line).groupdict()["codes"] == None
+    assert NOQA_REGEXP.search(line).groupdict()["codes"] is None
 
 
 @pytest.mark.parametrize(
     "line",
-    [("#noqa"), ("##noqa"), ("# n o q a"), ("#NOQA"), ("# Hello, noqa"),],
+    [("#noqa"), ("##noqa"), ("# n o q a"), ("#NOQA"), ("# Hello, noqa")],
 )
 def test_noqa_regex_not_present(line):
-    assert bool(NOQA_REGEXP.search(line)) == False
+    assert bool(NOQA_REGEXP.search(line)) is False
 
 
 def test_noqa_attributes(v):

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -25,7 +25,13 @@ def test_noqa_regex_present(line, codes):
 
 @pytest.mark.parametrize(
     "line",
-    [("# noqa: 123V"), ("# noqa explaination: V012"), ("# noqa: ,V101")],
+    [
+        ("# noqa: 123V"),
+        ("# noqa explaination: V012"),
+        ("# noqa: ,V101"),
+        ("# noqa: #noqa: V102"),
+        ("# noqa: # noqa: V102"),
+    ],
 )
 def test_noqa_regex_no_groups(line):
     assert NOQA_REGEXP.search(line).groupdict()["codes"] is None

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -243,13 +243,3 @@ import this  # V098, A123, F876
 """
     )
     check(v.unused_imports, ["this"])
-
-
-def test_noqa_with_special_unicode(v):
-    v.scan(
-        """\
-import abc  # noqa: V012, V😎12
-import problems  # noqa: V03🙃1
-"""
-    )
-    check(v.unused_imports, ["abc", "problems"])

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -27,7 +27,7 @@ def test_noqa_regex_present(line, codes):
     "line",
     [
         ("# noqa: 123V"),
-        ("# noqa explaination: V012"),
+        ("# noqa explanation: V012"),
         ("# noqa: ,V101"),
         ("# noqa: #noqa: V102"),
         ("# noqa: # noqa: V102"),
@@ -42,7 +42,7 @@ def test_noqa_regex_no_groups(line):
     [("#noqa"), ("##noqa"), ("# n o q a"), ("#NOQA"), ("# Hello, noqa")],
 )
 def test_noqa_regex_not_present(line):
-    assert bool(NOQA_REGEXP.search(line)) is False
+    assert not NOQA_REGEXP.search(line)
 
 
 def test_noqa_without_codes(v):
@@ -52,8 +52,8 @@ import this  # noqa
 
 class Cellar:  # noqa
     @property
-    def wine(self, grapes): # noqa
-        pass
+    def wine(self): # noqa
+        grapes = True  # noqa
 
     def serve(self, quantity=50):  # noqa
         self.quantity_served = quantity  # noqa
@@ -77,8 +77,8 @@ import this  # noqa: V104
 
 class Cellar:  # noqa: V102
     @property
-    def wine(self, grapes):  # noqa: V105, V106
-        pass
+    def wine(self):  # noqa: V105
+        grapes = True  # noqa: V106
 
     def serve(self, quantity=50):  # noqa: V103
         self.quantity_served = quantity  # noqa: V101
@@ -131,7 +131,6 @@ def play(tune, instrument='bongs', _hz='50'):  # noqa: V103
 
 # noqa
 def problems():  # noqa: V104
-    ''' They don't go away. :-)'''
     pass  # noqa: V103
 
 def hello(name):  # noqa

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -50,12 +50,14 @@ def test_noqa_without_codes(v):
         """\
 import this  # noqa
 
-class Cellar:  # noqa
-    @property
-    def wine(self): # noqa
+@underground  # noqa
+class Cellar:
+    @property  # noqa
+    def wine(self):
         grapes = True  # noqa
 
-    def serve(self, quantity=50):  # noqa
+    @without_ice  # noqa
+    def serve(self, quantity=50):
         self.quantity_served = quantity  # noqa
         return
         self.pour()  # noqa
@@ -75,12 +77,14 @@ def test_noqa_specific_issue_codes(v):
         """\
 import this  # noqa: V104
 
-class Cellar:  # noqa: V102
-    @property
-    def wine(self):  # noqa: V105
+@underground  # noqa: V102
+class Cellar:
+    @property  # noqa: V105
+    def wine(self):
         grapes = True  # noqa: V106
 
-    def serve(self, quantity=50):  # noqa: V103
+    @without_ice  # noqa: V103
+    def serve(self, quantity=50):
         self.quantity_served = quantity  # noqa: V101
         return
         self.pour()  # noqa: V201
@@ -160,35 +164,36 @@ def test_noqa_properties(v):
         """\
 class Zoo:
     @property
-    def no_of_coalas(self):  # noqa
+    def no_of_koalas(self):  # noqa
         pass
 
     @property
     def area(self, width, depth):  # noqa: V105
         pass
 
-    @property  # noqa  (should not be ignored)
+    @property  # noqa
     def entry_gates(self):
         pass
 
-    @property
-    def tickets(self):  # noqa: V103 (code for unused function)
+    @property  # noqa: V103 (code for unused function)
+    def tickets(self):
         pass
 """
     )
-    check(v.unused_props, ["entry_gates", "tickets"])
+    check(v.unused_props, ["no_of_koalas", "area", "tickets"])
     check(v.unused_classes, ["Zoo"])
     check(v.unused_vars, ["width", "depth"])
 
 
-def test_noqa_properties_multiple_decorators(v):
+def test_noqa_multiple_decorators(v):
     v.scan(
         """\
+@bar  # noqa: V102
 class Foo:
-    @property
+    @property  # noqa: V105
     @make_it_cool
     @log
-    def something(self):  # noqa: V105
+    def something(self):
         pass
 
     @coolify
@@ -203,7 +208,8 @@ class Foo:
         pass
 """
     )
-    check(v.unused_props, ["abcd"])
+    check(v.unused_props, ["something_else", "abcd"])
+    check(v.unused_classes, [])
 
 
 def test_noqa_unreacahble_code(v):

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vulture.noqa import NOQA_REGEXP, parse_error_codes
+from vulture.noqa import NOQA_REGEXP, _parse_error_codes
 from . import check, v
 
 assert v  # Silence pyflakes.
@@ -19,7 +19,7 @@ assert v  # Silence pyflakes.
 )
 def test_noqa_regex_present(line, codes):
     match = NOQA_REGEXP.search(line)
-    parsed = parse_error_codes(match)
+    parsed = _parse_error_codes(match)
     assert parsed == codes
 
 
@@ -277,3 +277,16 @@ import this  # V098, A123, F876
 """
     )
     check(v.unused_imports, ["this"])
+
+
+@pytest.mark.parametrize(
+    "first_file, second_file",
+    [
+        ("foo = None", "bar = None  # noqa"),
+        ("bar = None  # noqa", "foo = None"),
+    ],
+)
+def test_noqa_multiple_files(first_file, second_file, v):
+    v.scan(first_file, filename="first_file.py")
+    v.scan(second_file, filename="second_file.py")
+    check(v.unused_vars, ["foo"])

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vulture.core import NOQA_REGEXP
+from vulture.core import NOQA_REGEXP, _parse_error_codes
 from . import check, v
 
 assert v  # Silence pyflakes.
@@ -19,9 +19,7 @@ assert v  # Silence pyflakes.
 )
 def test_noqa_regex_present(line, codes):
     match = NOQA_REGEXP.search(line)
-    parsed = [
-        c.strip() for c in (match.groupdict()["codes"] or "all").split(",")
-    ]
+    parsed = _parse_error_codes(match)
     assert parsed == codes
 
 

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -1,0 +1,165 @@
+from . import check, v
+
+assert v  # Silence pyflakes.
+
+
+def test_noqa_attributes(v):
+    v.scan(
+        """\
+something.x = 'x'  # noqa: V001
+something.z = 'z'  # noqa: V006 (code for unused variable)
+something.u = 'u'  # noqa
+"""
+    )
+    check(v.get_unused_code(), ["z"])
+
+
+def test_noqa_classes(v):
+    v.scan(
+        """\
+class QtWidget:  # noqa: V002
+    pass
+
+class ABC(QtWidget):
+    pass  # noqa: V002 (should not ignore)
+
+class DEF:  # noqa
+    pass
+"""
+    )
+    check(v.get_unused_code(), ["ABC"])
+
+
+def test_noqa_functions(v):
+    v.scan(
+        """\
+def play(tune, instrument='bongs', _hz='50'):  # noqa: V003
+    pass
+
+
+# noqa
+def problems():  # noqa: V004
+    ''' They don't go away. :-)'''
+    pass  # noqa: V003
+
+def hello(name):  # noqa
+    print("Hello")
+"""
+    )
+    check(v.get_unused_code(), ["tune", "instrument", "problems"])
+
+
+def test_noqa_imports(v):
+    v.scan(
+        """\
+import foo
+import this  # noqa: V004
+import zoo
+from koo import boo  # noqa
+from me import *
+import dis  # noqa: V001 (code for unused attr)
+"""
+    )
+    check(v.get_unused_code(), ["foo", "zoo", "dis"])
+
+
+def test_noqa_propoerties(v):
+    v.scan(
+        """\
+class Zoo:
+    @property  # noqa
+    def no_of_coalas(self):
+        pass
+
+    @property  # noqa: V005
+    def area(self, width, depth):  
+        pass
+
+    @property
+    def entry_gates(self):  # noqa
+        pass
+
+    @property  # noqa: V003 (code for unused function)
+    def tickets(self):
+        pass
+"""
+    )
+    check(
+        v.get_unused_code(),
+        ["Zoo", "width", "depth", "entry_gates", "tickets"],
+    )
+
+
+def test_noqa_unreacahble_code(v):
+    v.scan(
+        """\
+def shave_sheeps(sheeps):  # noqa: V003
+    for sheep in sheeps:
+        if sheep.bald:
+            continue
+            sheep.grow_hair()  # noqa: V006
+        sheep.shave()
+    return sheeps
+    for sheep in sheeps:  # noqa: V006
+        if sheep.still_has_hair:
+            sheep.shave_again()
+"""
+    )
+    check(v.get_unused_code(), [])
+
+
+def test_noqa_variables(v):
+    v.scan(
+        """\
+mitsi = "Mother"  # noqa: V007
+harry = "Father"  # noqa
+shero = "doggy"   # noqa: V001, V004 (code for unused import, attr)
+shinchan.friend = ['masao']  # noqa: V007
+"""
+    )
+    check(v.get_unused_code(), ["shero", "friend"])
+
+
+def test_noqa_with_multiple_issue_codes(v):
+    v.scan(
+        """\
+def world(axis):  # noqa: V003, V006
+    pass
+
+
+for _ in range(3):
+    continue
+    xyz = hello(something, else):  # noqa: V006, V007
+"""
+    )
+    check(v.get_unused_code(), [])
+
+
+def test_noqa_on_empty_line(v):
+    v.scan(
+        """\
+# noqa
+import this
+# noqa
+"""
+    )
+    check(v.get_unused_code(), ["this"])
+
+
+def test_noqa_with_invalid_codes(v):
+    v.scan(
+        """\
+import this  # V098, A123, F876
+"""
+    )
+    check(v.get_unused_code(), ["this"])
+
+
+def test_noqa_with_special_unicode(v):
+    v.scan(
+        """\
+import abc  # noqa: V012, V😎12
+import problems  # noqa: V03🙃1
+"""
+    )
+    check(v.get_unused_code(), ["abc", "problems"])

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -25,7 +25,7 @@ def test_noqa_regex_present(line, codes):
 
 @pytest.mark.parametrize(
     "line",
-    [("# noqa: 123V"), ("# noqa explaination: V012"), ("# noqa: ,V001"),],
+    [("# noqa: 123V"), ("# noqa explaination: V012"), ("# noqa: ,V001")],
 )
 def test_noqa_regex_no_groups(line):
     assert NOQA_REGEXP.search(line).groupdict()["codes"] is None

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -41,6 +41,56 @@ def test_noqa_regex_not_present(line):
     assert bool(NOQA_REGEXP.search(line)) is False
 
 
+def test_noqa_without_codes(v):
+    v.scan(
+        """\
+import this  # noqa
+
+class Cellar:  # noqa
+    @propoerty  # noqa
+    def wine(self, grapes): # noqa
+        pass
+
+    def serve(self, quantity=50):  # noqa
+        self.quantity_served = quantity  # noqa
+        return
+        self.pour()  # noqa
+"""
+    )
+    check(v.unused_attrs, [])
+    check(v.unused_classes, [])
+    check(v.unused_funcs, [])
+    check(v.unused_imports, [])
+    check(v.unused_props, [])
+    check(v.unreachable_code, [])
+    check(v.unused_vars, [])
+
+
+def test_noqa_specific_issue_codes(v):
+    v.scan(
+        """\
+import this  # noqa: V004
+
+class Cellar:  # noqa: V002
+    @property  # noqa: V005
+    def wine(self, grapes):  # noqa: V007
+        pass
+
+    def serve(self, quantity=50):  # noqa: V003
+        self.quantity_served = quantity  # noqa: V001
+        return
+        self.pour()  # noqa: V006
+"""
+    )
+    check(v.unused_attrs, [])
+    check(v.unused_classes, [])
+    check(v.unused_funcs, [])
+    check(v.unused_imports, [])
+    check(v.unused_props, [])
+    check(v.unreachable_code, [])
+    check(v.unused_vars, [])
+
+
 def test_noqa_attributes(v):
     v.scan(
         """\

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -11,7 +11,7 @@ something.z = 'z'  # noqa: V006 (code for unused variable)
 something.u = 'u'  # noqa
 """
     )
-    check(v.get_unused_code(), ["z"])
+    check(v.unused_attrs, ["z"])
 
 
 def test_noqa_classes(v):
@@ -27,7 +27,7 @@ class DEF:  # noqa
     pass
 """
     )
-    check(v.get_unused_code(), ["ABC"])
+    check(v.unused_classes, ["ABC"])
 
 
 def test_noqa_functions(v):
@@ -46,7 +46,8 @@ def hello(name):  # noqa
     print("Hello")
 """
     )
-    check(v.get_unused_code(), ["tune", "instrument", "problems"])
+    check(v.unused_funcs, ["problems"])
+    check(v.unused_vars, ["instrument", "tune"])
 
 
 def test_noqa_imports(v):
@@ -60,7 +61,7 @@ from me import *
 import dis  # noqa: V001 (code for unused attr)
 """
     )
-    check(v.get_unused_code(), ["foo", "zoo", "dis"])
+    check(v.unused_imports, ["foo", "zoo", "dis"])
 
 
 def test_noqa_propoerties(v):
@@ -84,16 +85,15 @@ class Zoo:
         pass
 """
     )
-    check(
-        v.get_unused_code(),
-        ["Zoo", "width", "depth", "entry_gates", "tickets"],
-    )
+    check(v.unused_props, ['entry_gates', 'tickets'])
+    check(v.unused_classes, ['Zoo'])
+    check(v.unused_vars, ["width", "depth"])
 
 
 def test_noqa_unreacahble_code(v):
     v.scan(
         """\
-def shave_sheeps(sheeps):  # noqa: V003
+def shave_sheeps(sheeps):
     for sheep in sheeps:
         if sheep.bald:
             continue
@@ -105,7 +105,8 @@ def shave_sheeps(sheeps):  # noqa: V003
             sheep.shave_again()
 """
     )
-    check(v.get_unused_code(), [])
+    check(v.unreachable_code, [])
+    check(v.unused_funcs, ["shave_sheeps"])
 
 
 def test_noqa_variables(v):
@@ -117,7 +118,8 @@ shero = "doggy"   # noqa: V001, V004 (code for unused import, attr)
 shinchan.friend = ['masao']  # noqa: V007
 """
     )
-    check(v.get_unused_code(), ["shero", "friend"])
+    check(v.unused_vars, ["shero"])
+    check(v.unused_attrs, ["friend"])
 
 
 def test_noqa_with_multiple_issue_codes(v):
@@ -143,7 +145,7 @@ import this
 # noqa
 """
     )
-    check(v.get_unused_code(), ["this"])
+    check(v.unused_imports, ["this"])
 
 
 def test_noqa_with_invalid_codes(v):
@@ -152,7 +154,7 @@ def test_noqa_with_invalid_codes(v):
 import this  # V098, A123, F876
 """
     )
-    check(v.get_unused_code(), ["this"])
+    check(v.unused_imports, ["this"])
 
 
 def test_noqa_with_special_unicode(v):
@@ -162,4 +164,4 @@ import abc  # noqa: V012, V😎12
 import problems  # noqa: V03🙃1
 """
     )
-    check(v.get_unused_code(), ["abc", "problems"])
+    check(v.unused_imports, ["abc", "problems"])

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -37,13 +37,13 @@ def check_report(v, capsys):
 
 def test_item_report(check_report):
     expected = """\
-{filename}:1: unused import 'foo' (90% confidence)
-{filename}:3: unused class 'Foo' (60% confidence)
-{filename}:7: unused function 'bar' (60% confidence)
-{filename}:8: unused attribute 'foobar' (60% confidence)
-{filename}:9: unused variable 'foobar' (60% confidence)
-{filename}:11: unreachable code after 'return' (100% confidence)
-{filename}:13: unused property 'myprop' (60% confidence)
+<V004> {filename}:1: unused import 'foo' (90% confidence)
+<V002> {filename}:3: unused class 'Foo' (60% confidence)
+<V003> {filename}:7: unused function 'bar' (60% confidence)
+<V001> {filename}:8: unused attribute 'foobar' (60% confidence)
+<V007> {filename}:9: unused variable 'foobar' (60% confidence)
+<V006> {filename}:11: unreachable code after 'return' (100% confidence)
+<V005> {filename}:13: unused property 'myprop' (60% confidence)
 """
     check_report(mock_code, expected)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -37,13 +37,13 @@ def check_report(v, capsys):
 
 def test_item_report(check_report):
     expected = """\
-{filename}:1: V004 unused import 'foo' (90% confidence)
-{filename}:3: V002 unused class 'Foo' (60% confidence)
-{filename}:7: V003 unused function 'bar' (60% confidence)
-{filename}:8: V001 unused attribute 'foobar' (60% confidence)
-{filename}:9: V007 unused variable 'foobar' (60% confidence)
-{filename}:11: V006  unreachable code after 'return' (100% confidence)
-{filename}:13: V005  unused property 'myprop' (60% confidence)
+{filename}:1: V104 unused import 'foo' (90% confidence)
+{filename}:3: V102 unused class 'Foo' (60% confidence)
+{filename}:7: V103 unused function 'bar' (60% confidence)
+{filename}:8: V101 unused attribute 'foobar' (60% confidence)
+{filename}:9: V106 unused variable 'foobar' (60% confidence)
+{filename}:11: V201 unreachable code after 'return' (100% confidence)
+{filename}:13: V105 unused property 'myprop' (60% confidence)
 """
     check_report(mock_code, expected)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -37,13 +37,13 @@ def check_report(v, capsys):
 
 def test_item_report(check_report):
     expected = """\
-<V004> {filename}:1: unused import 'foo' (90% confidence)
-<V002> {filename}:3: unused class 'Foo' (60% confidence)
-<V003> {filename}:7: unused function 'bar' (60% confidence)
-<V001> {filename}:8: unused attribute 'foobar' (60% confidence)
-<V007> {filename}:9: unused variable 'foobar' (60% confidence)
-<V006> {filename}:11: unreachable code after 'return' (100% confidence)
-<V005> {filename}:13: unused property 'myprop' (60% confidence)
+{filename}:1: V004 unused import 'foo' (90% confidence)
+{filename}:3: V002 unused class 'Foo' (60% confidence)
+{filename}:7: V003 unused function 'bar' (60% confidence)
+{filename}:8: V001 unused attribute 'foobar' (60% confidence)
+{filename}:9: V007 unused variable 'foobar' (60% confidence)
+{filename}:11: V006  unreachable code after 'return' (100% confidence)
+{filename}:13: V005  unused property 'myprop' (60% confidence)
 """
     check_report(mock_code, expected)
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,3 +1,4 @@
+import glob
 import os.path
 import subprocess
 import sys
@@ -61,12 +62,7 @@ def test_exclude():
         return call_vulture(["vulture/", "--exclude", get_csv(excludes)])
 
     assert call_vulture_with_excludes(["core.py", "utils.py"]) == 1
-    assert (
-        call_vulture_with_excludes(
-            ["core.py", "utils.py", "lines.py", "noqa.py"]
-        )
-        == 0
-    )
+    assert call_vulture_with_excludes(glob.glob("vulture/*.py")) == 0
 
 
 def test_make_whitelist():

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -61,7 +61,12 @@ def test_exclude():
         return call_vulture(["vulture/", "--exclude", get_csv(excludes)])
 
     assert call_vulture_with_excludes(["core.py", "utils.py"]) == 1
-    assert call_vulture_with_excludes(["core.py", "utils.py", "lines.py"]) == 0
+    assert (
+        call_vulture_with_excludes(
+            ["core.py", "utils.py", "lines.py", "noqa.py"]
+        )
+        == 0
+    )
 
 
 def test_make_whitelist():

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -27,7 +27,6 @@ from __future__ import print_function
 
 import argparse
 import ast
-from collections import defaultdict
 from fnmatch import fnmatch, fnmatchcase
 import os.path
 import pkgutil
@@ -476,13 +475,11 @@ class Vulture(ast.NodeVisitor):
         ignore=None,
     ):
         def ignored(lineno):
-            if (ignore and ignore(self.filename, name)) or _match(
-                name, self.ignore_names
-            ):
-                return True
-
-            # Check if the reported line is annotated with "# noqa".
-            return noqa.ignore_line(self.noqa_lines, lineno, typ)
+            return (
+                (ignore and ignore(self.filename, name))
+                or _match(name, self.ignore_names)
+                or noqa.ignore_line(self.noqa_lines, lineno, ERROR_CODES[typ])
+            )
 
         last_node = last_node or first_node
         typ = collection.typ

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -500,9 +500,8 @@ class Vulture(ast.NodeVisitor):
         ignore=None,
     ):
         def ignored(name):
-            return (
-                (ignore and ignore(self.filename, name))
-                or _match(name, self.ignore_names)
+            return (ignore and ignore(self.filename, name)) or _match(
+                name, self.ignore_names
             )
 
         def has_noqa(lineno, typ):

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -48,13 +48,13 @@ if sys.version_info < (3, 4):
     IGNORED_VARIABLE_NAMES |= {"True", "False"}
 
 ERROR_CODES = {
-    "attribute": "V001",
-    "class": "V002",
-    "function": "V003",
-    "import": "V004",
-    "property": "V005",
-    "unreachable_code": "V006",
-    "variable": "V007",
+    "attribute": "V101",
+    "class": "V102",
+    "function": "V103",
+    "import": "V104",
+    "property": "V105",
+    "unreachable_code": "V201",
+    "variable": "V106",
 }
 
 NOQA_REGEXP = re.compile(
@@ -77,9 +77,13 @@ def _get_unused_items(defined_items, used_names):
     unused_items.sort(key=lambda item: item.name.lower())
     return unused_items
 
+
 def _parse_error_codes(match):
     # if no code is specified, assign it to `all`
-    return [c.strip() for c in (match.groupdict()["codes"] or "all").split(",")]
+    return [
+        c.strip() for c in (match.groupdict()["codes"] or "all").split(",")
+    ]
+
 
 def _is_special_name(name):
     return name.startswith("__") and name.endswith("__")

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -79,7 +79,7 @@ def _get_unused_items(defined_items, used_names):
 
 
 def _parse_error_codes(match):
-    # if no code is specified, assign it to `all`
+    # If no error code is specified, add the line to the "all" category.
     return [
         c.strip() for c in (match.groupdict()["codes"] or "all").split(",")
     ]
@@ -507,13 +507,7 @@ class Vulture(ast.NodeVisitor):
             ):
                 return True
 
-            # if name not ignored, check if annotated with "# noqa"
-            if typ == "property" and sys.version_info < (3, 8):
-                # For python < 3.8, increment as many line numbers as there are
-                # decorators on the method.
-                # From python3.8 onwards, lineno for property is the same as
-                # that of the decorated method.
-                lineno = lineno + len(first_node.decorator_list)
+            # Check if the reported line is annotated with "# noqa".
             return (
                 lineno in self.noqa_matches[ERROR_CODES[typ]]
                 or lineno in self.noqa_matches["all"]
@@ -521,12 +515,11 @@ class Vulture(ast.NodeVisitor):
 
         last_node = last_node or first_node
         typ = collection.typ
-        first_lineno = first_node.lineno
+        first_lineno = lines.get_first_line_number(first_node)
 
         if ignored(first_lineno):
             self._log('Ignoring {typ} "{name}"'.format(**locals()))
         else:
-            first_lineno = lines.get_first_line_number(first_node)
             last_lineno = lines.get_last_line_number(last_node)
             collection.append(
                 Item(
@@ -539,7 +532,6 @@ class Vulture(ast.NodeVisitor):
                     confidence=confidence,
                 )
             )
-        )
 
     def _define_variable(self, name, node, confidence=DEFAULT_CONFIDENCE):
         self._define(

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -2,7 +2,7 @@
 #
 # vulture - Find dead code.
 #
-# Copyright (c) 2012-2019 Jendrik Seipp (jendrikseipp@gmail.com)
+# Copyright (c) 2012-2020 Jendrik Seipp (jendrikseipp@gmail.com)
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -171,10 +171,10 @@ class Item(object):
             size_report = ", {:d} {}".format(self.size, line_format)
         else:
             size_report = ""
-        return "<{}> {}:{:d}: {} ({}% confidence{})".format(
-            ERROR_CODES[self.typ],
+        return "{}:{:d}: {} {} ({}% confidence{})".format(
             utils.format_path(self.filename),
             self.first_lineno,
+            ERROR_CODES[self.typ],
             self.message,
             self.confidence,
             size_report,
@@ -509,9 +509,7 @@ class Vulture(ast.NodeVisitor):
                 # decorators on the method.
                 # python3.8 onwards, lineno for property is the same as that of
                 # the decorated method.
-                print("buahahahaha")
                 lineno = lineno + len(first_node.decorator_list)
-                print('d ', lineno)
             return lineno in (
                 self.noqa_matches[ERROR_CODES[typ]].union(
                     self.noqa_matches["all"]

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -505,6 +505,10 @@ class Vulture(ast.NodeVisitor):
             )
 
         def has_noqa(lineno, typ):
+            if typ == "property" and sys.version_info >= (3, 8):
+                # python3.8 onwards, lineno for property is the same as that of
+                # the decorated method.
+                lineno = lineno - 1
             return lineno in (
                 self.noqa_matches[ERROR_CODES[typ]].union(
                     self.noqa_matches["all"]

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -77,6 +77,9 @@ def _get_unused_items(defined_items, used_names):
     unused_items.sort(key=lambda item: item.name.lower())
     return unused_items
 
+def _parse_error_codes(match):
+    # if no code is specified, assign it to `all`
+    return [c.strip() for c in (match.groupdict()["codes"] or "all").split(",")]
 
 def _is_special_name(name):
     return name.startswith("__") and name.endswith("__")
@@ -239,12 +242,7 @@ class Vulture(ast.NodeVisitor):
         for lineno, line in enumerate(code, start=1):
             match = NOQA_REGEXP.search(line)
             if match:
-                codes = [
-                    c.strip()
-                    # if no code is specified, assign it to `all`
-                    for c in (match.groupdict()["codes"] or "all").split(",")
-                ]
-                for code in codes:
+                for code in _parse_error_codes(match):
                     self.noqa_matches[code].add(lineno)
 
     def scan(self, code, filename=""):

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -168,7 +168,8 @@ class Item(object):
             size_report = ", {:d} {}".format(self.size, line_format)
         else:
             size_report = ""
-        return "{}:{:d}: {} ({}% confidence{})".format(
+        return "<{}> {}:{:d}: {} ({}% confidence{})".format(
+            ERROR_CODES[self.typ],
             utils.format_path(self.filename),
             self.first_lineno,
             self.message,

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -509,15 +509,14 @@ class Vulture(ast.NodeVisitor):
 
             # if name not ignored, check if annotated with "# noqa"
             if typ == "property" and sys.version_info < (3, 8):
-                # for python < 3.8, increment as many line numbers as there are
+                # For python < 3.8, increment as many line numbers as there are
                 # decorators on the method.
-                # python3.8 onwards, lineno for property is the same as that of
-                # the decorated method.
+                # From python3.8 onwards, lineno for property is the same as
+                # that of the decorated method.
                 lineno = lineno + len(first_node.decorator_list)
-            return lineno in (
-                self.noqa_matches[ERROR_CODES[typ]].union(
-                    self.noqa_matches["all"]
-                )
+            return (
+                lineno in self.noqa_matches[ERROR_CODES[typ]]
+                or lineno in self.noqa_matches["all"]
             )
 
         last_node = last_node or first_node

--- a/vulture/lines.py
+++ b/vulture/lines.py
@@ -1,3 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# vulture - Find dead code.
+#
+# Copyright (c) 2012-2020 Jendrik Seipp (jendrikseipp@gmail.com)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import ast
 import sys
 

--- a/vulture/noqa.py
+++ b/vulture/noqa.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+import re
+
+NOQA_REGEXP = re.compile(
+    # Use the same regex as flake8 does.
+    # https://gitlab.com/pycqa/flake8/-/tree/master/src/flake8/defaults.py
+    # We're looking for items that look like this:
+    # `# noqa`
+    # `# noqa: E123`
+    # `# noqa: E123,W451,F921`
+    # `# NoQA: E123,W451,F921`
+    r"# noqa(?::[\s]?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?",
+    re.IGNORECASE,
+)
+
+
+def parse_error_codes(match):
+    # If no error code is specified, add the line to the "all" category.
+    return [
+        c.strip() for c in (match.groupdict()["codes"] or "all").split(",")
+    ]
+
+
+def parse_noqa(code):
+    noqa_lines = defaultdict(set)
+    for lineno, line in enumerate(code, start=1):
+        match = NOQA_REGEXP.search(line)
+        if match:
+            for error_code in parse_error_codes(match):
+                noqa_lines[error_code].add(lineno)
+    return noqa_lines
+
+
+def ignore_line(noqa_lines, lineno, typ):
+    """Check if the reported line is annotated with "# noqa"."""
+    from vulture.core import ERROR_CODES
+
+    return (
+        lineno in noqa_lines[ERROR_CODES[typ]] or lineno in noqa_lines["all"]
+    )

--- a/vulture/noqa.py
+++ b/vulture/noqa.py
@@ -1,3 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# vulture - Find dead code.
+#
+# Copyright (c) 2012-2020 Jendrik Seipp (jendrikseipp@gmail.com)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 from collections import defaultdict
 import re
 

--- a/vulture/noqa.py
+++ b/vulture/noqa.py
@@ -14,7 +14,7 @@ NOQA_REGEXP = re.compile(
 )
 
 
-def parse_error_codes(match):
+def _parse_error_codes(match):
     # If no error code is specified, add the line to the "all" category.
     return [
         c.strip() for c in (match.groupdict()["codes"] or "all").split(",")
@@ -26,15 +26,11 @@ def parse_noqa(code):
     for lineno, line in enumerate(code, start=1):
         match = NOQA_REGEXP.search(line)
         if match:
-            for error_code in parse_error_codes(match):
+            for error_code in _parse_error_codes(match):
                 noqa_lines[error_code].add(lineno)
     return noqa_lines
 
 
-def ignore_line(noqa_lines, lineno, typ):
+def ignore_line(noqa_lines, lineno, error_code):
     """Check if the reported line is annotated with "# noqa"."""
-    from vulture.core import ERROR_CODES
-
-    return (
-        lineno in noqa_lines[ERROR_CODES[typ]] or lineno in noqa_lines["all"]
-    )
+    return lineno in noqa_lines[error_code] or lineno in noqa_lines["all"]

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -1,3 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# vulture - Find dead code.
+#
+# Copyright (c) 2012-2020 Jendrik Seipp (jendrikseipp@gmail.com)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import ast
 import codecs
 import os


### PR DESCRIPTION
Hey, 

## Description

This PR isn't production-ready by any means, but I just wanted to have an idea about the complexity it would add to Vulture to support `# noqa` comments. I'd be happy to add tests and documentation, once we all settle if it would be a good idea to carry this forward.

Another change with the introduction of `# noqa` comments would be the introduction of issue codes (it's possible without these as well, but would hurt specificity). For now, I've just added `V001`, `V002`, ... - the nomenclature for these issue codes is another thing to think about.

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, please link to it here: -->

#160, #182, #190 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation in the README file.
- [x] I have updated the documentation accordingly.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
