### PR TITLE
Add support for finding empty files

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -39,10 +39,20 @@ def test_non_utf8_encoding(v, tmpdir):
 
 
 def test_utf8_with_bom(v, tmpdir):
-    name = "utf8_bom"
+    name = "test_utf8_bom"
     filename = str(tmpdir.mkdir(name).join(name + ".py"))
     # utf8_sig prepends the BOM to the file.
     with io.open(filename, mode="w", encoding="utf-8-sig") as f:
         f.write(u"")
     v.scavenge([f.name])
     assert not v.found_dead_code_or_error
+
+
+def test_file_without_code(v, tmpdir):
+    code = "# this is not code, its a comment"
+    name = "no_code"
+    filename = str(tmpdir.mkdir(name).join(name + ".py"))
+    with open(filename, "w+") as f:
+        f.write(code)
+    v.scavenge([f.name])
+    assert v.found_dead_code_or_error


### PR DESCRIPTION
Currently, empty files are not picked up by Vulture. They probably should be.

## Description
Once files are parsed, I check to see if there are any items in the tree. If not, there is no "code" in the file: notify the user of the empty file.

## Related Issue
#197

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation in the README file. (may be nice)
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry in CHANGELOG.md.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Add upon the emtpy files that should be ignored (other then `__init__.py`).