### PR TITLE
add trove classifier for py38

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Quality Assurance",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add trove classifier for Python3.8

Add trove classifier for Python3.8. Thought it was too small a change to be creating an issue.

As an aside, can't we open the files, read its contents, assign it to a variable and use that variable in the `long_description` argument to `setup()` in setup.py instead of opening it then and there?

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, please link to it here: -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation in the README file.
- [] I have updated the documentation accordingly.
- [] I have added an entry in CHANGELOG.md.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
