### PR TITLE
Treat `getattr(obj, "constant_string", default)` as a reference to `obj.constant_string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Consider all files under `test` or `tests` directories test files
   (Jendrik Seipp).
 * Ignore `logging.Logger.propagate` attribute (Jendrik Seipp).
+* Treat `getattr/hasattr(obj, "constant_string", ...)` as a reference to
+  `obj.constant_string`. (jingw, #219)
 
 # 1.6 (2020-07-28)
 

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -146,6 +146,30 @@ A._d_ = 4
     check(v.unused_vars, [])
 
 
+def test_getattr(v):
+    v.scan(
+        """\
+class Thing:
+    used_attr1 = 1
+    used_attr2 = 2
+    used_attr3 = 3
+    unused_attr = 4
+
+getattr(Thing, "used_attr1")
+getattr(Thing, "used_attr2", None)
+hasattr(Thing, "used_attr3")
+
+# Weird calls ignored
+hasattr(Thing, "unused_attr", None)
+getattr(Thing)
+getattr("unused_attr")
+getattr(Thing, "unused_attr", 1, 2)
+"""
+    )
+    check(v.unused_vars, ["unused_attr"])
+    check(v.used_attrs, ["used_attr1", "used_attr2", "used_attr3"])
+
+
 def test_callback1(v):
     v.scan(
         """\

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -510,6 +510,16 @@ class Vulture(ast.NodeVisitor):
         elif isinstance(node.ctx, ast.Load):
             self.used_attrs.add(node.attr)
 
+    def visit_Call(self, node):
+        """Count getattr/hasattr(x, "some_attr", ...) as usage of some_attr."""
+        if isinstance(node.func, ast.Name) and (
+            (node.func.id == "getattr" and 2 <= len(node.args) <= 3)
+            or (node.func.id == "hasattr" and len(node.args) == 2)
+        ):
+            attr_name_arg = node.args[1]
+            if isinstance(attr_name_arg, ast.Str):
+                self.used_attrs.add(attr_name_arg.s)
+
     def visit_ClassDef(self, node):
         for decorator in node.decorator_list:
             if _match(


### PR DESCRIPTION
## Description
I realize handling `getattr` is a slippery slope. I think this case makes sense and is a reasonable place to draw the line.

My rationale is that the following code does the same thing, counts as a reference to obj.constant_string, but is not what most people would write.
```
try:
    x = obj.constant_string
except AttributeError:
    x = None
```

## Related Issue
Haven't filed one. Happy to discuss this makes sense or not.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation in the README.md file.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
