### PR TITLE
Parse mypy type comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Consider all files under `test` or `tests` directories test files
   (Jendrik Seipp).
 * Ignore `logging.Logger.propagate` attribute (Jendrik Seipp).
+* Parse mypy / PEP 484 / PEP 526 `# type: ...` comments if on Python 3.8+.
+  (jingw, #220)
 
 # 1.6 (2020-07-28)
 

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -1,3 +1,5 @@
+import sys
+
 from . import check, v
 
 assert v  # Silence pyflakes.
@@ -644,16 +646,46 @@ x: List[int] = [1]
 def test_type_hint_comments(v):
     v.scan(
         """\
-import typing
+from typing import Any, Dict, List, Text, Tuple
 
-if typing.TYPE_CHECKING:
-    from typing import List, Text
 
-def foo(foo_li):
-    # type: (List[Text]) -> None
-    for bar in foo_li:
-        bar.xyz()
+def plain_function(arg):
+    # type: (Text) -> None
+    pass
+
+async def async_function(arg):
+    # type: (List[int]) -> None
+    pass
+
+some_var = {}  # type: Dict[str, str]
+
+class Thing:
+    def __init__(self):
+        self.some_attr = (1, 2)  # type: Tuple[int, int]
+
+for x in []:  # type: Any
+    print(x)
 """
     )
 
-    check(v.unused_imports, ["List", "Text"])
+    if sys.version_info < (3, 8):
+        check(v.unused_imports, ["Any", "Dict", "List", "Text", "Tuple"])
+    else:
+        check(v.unused_imports, [])
+        assert not v.found_dead_code_or_error
+
+
+def test_invalid_type_comment(v):
+    v.scan(
+        """\
+def bad():
+    # type: bogus
+    pass
+bad()
+"""
+    )
+
+    if sys.version_info < (3, 8):
+        assert not v.found_dead_code_or_error
+    else:
+        assert v.found_dead_code_or_error

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -203,15 +203,23 @@ class Vulture(ast.NodeVisitor):
         self.code = code.splitlines()
         self.noqa_lines = noqa.parse_noqa(self.code)
         self.filename = filename
-        try:
-            node = ast.parse(code, filename=self.filename)
-        except SyntaxError as err:
-            text = f' at "{err.text.strip()}"' if err.text else ""
+
+        def handle_syntax_error(e):
+            text = f' at "{e.text.strip()}"' if e.text else ""
             print(
-                f"{utils.format_path(filename)}:{err.lineno}: {err.msg}{text}",
+                f"{utils.format_path(filename)}:{e.lineno}: {e.msg}{text}",
                 file=sys.stderr,
             )
             self.found_dead_code_or_error = True
+
+        try:
+            node = (
+                ast.parse(code, filename=self.filename, type_comments=True)
+                if sys.version_info >= (3, 8)  # type_comments requires 3.8+
+                else ast.parse(code, filename=self.filename)
+            )
+        except SyntaxError as err:
+            handle_syntax_error(err)
         except ValueError as err:
             # ValueError is raised if source contains null bytes.
             print(
@@ -220,7 +228,11 @@ class Vulture(ast.NodeVisitor):
             )
             self.found_dead_code_or_error = True
         else:
-            self.visit(node)
+            # When parsing type comments, visiting can throw SyntaxError.
+            try:
+                self.visit(node)
+            except SyntaxError as err:
+                handle_syntax_error(err)
 
     def scavenge(self, paths, exclude=None):
         def prepare_pattern(pattern):
@@ -603,6 +615,20 @@ class Vulture(ast.NodeVisitor):
             self._log(lineno, ast.dump(node), line)
         if visitor:
             visitor(node)
+
+        # There isn't a clean subset of node types that might have type
+        # comments, so just check all of them.
+        type_comment = getattr(node, "type_comment", None)
+        if type_comment is not None:
+            mode = (
+                "func_type"
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                else "eval"
+            )
+            self.visit(
+                ast.parse(type_comment, filename="<type_comment>", mode=mode)
+            )
+
         return self.generic_visit(node)
 
     def _handle_ast_list(self, ast_list):


### PR DESCRIPTION
## Description

This prevents type-only imports from being flagged as unused.

Implementation decision note: As typed_ast will not be updated to support parsing Python 3.8+ syntax, I'm choosing not to use it. The downside of using Python's built-in type comment support is that it requires Python 3.8+. Someone more motivated than me could potentially make vulture use both, but I don't feel it's worth the complexity/effort given typed_ast seems likely to eventually die.

## Related Issue
Fixes #152
See also #153

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation in the README.md file. (but do you want this in the README? not sure how much you want there versus left to --help)
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
