### PR TITLE
Combine used_attrs and used_names to avoid false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # unreleased
 * Treat `getattr/hasattr(obj, "constant_string", ...)` as a reference to
   `obj.constant_string` (jingw, #219).
+* Fix false positives when assigning to `x.some_name` but reading via
+  `some_name`, at the cost of potential false negatives. (jingw, #221)
 
 # 2.0 (2020-08-11)
 

--- a/tests/test_format_strings.py
+++ b/tests/test_format_strings.py
@@ -10,7 +10,7 @@ def test_old_format_string(v):
 
 def test_new_format_string(v):
     v.scan("'{a}, {b:0d} {c:<30} {d:.2%}'.format(**locals())")
-    check(v.used_names, ["a", "b", "c", "d", "locals"])
+    check(v.used_names, ["a", "b", "c", "d", "format", "locals"])
 
 
 def test_f_string(v):
@@ -27,24 +27,19 @@ f'{ {x:y for (x, y) in ((1, 2), (3, 4))} }'
 
 
 def test_new_format_string_access(v):
-    v.scan("'{a.b}, {c.d.e} {f[g]} {h[i][j]}'.format(**locals())")
-    check(v.used_names, ["a", "c", "f", "h", "locals"])
-
-
-def test_new_format_string_attributes(v):
     v.scan("'{a.b}, {c.d.e} {f[g]} {h[i][j].k}'.format(**locals())")
-    check(v.used_names, ["a", "c", "f", "h", "locals"])
-    check(v.used_attrs, ["b", "d", "e", "k", "format"])
+    check(
+        v.used_names,
+        ["a", "b", "c", "d", "e", "f", "h", "k", "format", "locals"],
+    )
 
 
 def test_new_format_string_numbers(v):
     v.scan("'{0.b}, {0.d.e} {0[1]} {0[1][1].k}'.format('foo')")
-    check(v.used_names, [])
-    check(v.used_attrs, ["b", "d", "e", "k", "format"])
+    check(v.used_names, ["b", "d", "e", "k", "format"])
 
 
 def test_incorrect_format_string(v):
     v.scan('"{"')
     v.scan('"{!-a:}"')
     check(v.used_names, [])
-    check(v.used_attrs, [])

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -90,10 +90,10 @@ def test_attribute():
     code = """\
 class Foo:
     def __init__(self, attr_foo, attr_bar):
-        self.attr_foo = attr_foo
-        self.attr_bar = attr_bar
+        self._attr_foo = attr_foo
+        self._attr_bar = attr_bar
 """
-    check_ignore(code, ["foo", "*_foo"], [], ["Foo", "attr_bar"])
+    check_ignore(code, ["foo", "*_foo"], [], ["Foo", "_attr_bar"])
 
 
 def test_decorated_functions():

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -59,7 +59,7 @@ os.path.expanduser("~")
 """
     )
     check(v.defined_imports, ["os"])
-    check(v.used_names, ["os"])
+    check(v.used_names, ["os", "path", "expanduser"])
     check(v.unused_funcs, [])
     check(v.unused_imports, [])
     check(v.unused_vars, [])


### PR DESCRIPTION
## Description
This fixes false positives when assigning to `x.some_name` but reading via `some_name`.
Note this produces false negatives in the opposite situation when `x.some_name` and `some_name` are different, so this is a trade-off in the direction of more precision / less sensitivity.

This direction is in line with pyflakes design principles: https://github.com/PyCQA/pyflakes#design-principles
> it will try very, very hard to never emit false positives.

Fixing this more accurately probably requires a lot more work to trace references and analyze context.

## Related Issue
#221

## Checklist:
- [x] My code follows the code style of this project.
- N/A I have updated the documentation in the README.md file.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
