### PR TITLE
Don't override TOML paths with empty CLI paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 * Only parse format strings when being used with `locals()` (jingw, #225).
+* Don't override paths in pyproject.toml with empty CLI paths (bcbnz, #228).
 
 # 2.1 (2020-08-19)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -147,6 +147,27 @@ def test_config_merging_missing():
     assert result["ignore_names"] == ["name1"]
 
 
+def test_config_merging_toml_paths_only():
+    """
+    If we have paths in the TOML but not on the CLI, the TOML paths should be
+    used.
+    """
+    toml = StringIO(
+        dedent(
+            """\
+        [tool.vulture]
+        paths = ["path1", "path2"]
+        """
+        )
+    )
+    cliargs = [
+        "--exclude=test_*.py",
+    ]
+    result = make_config(cliargs, toml)
+    assert result["paths"] == ["path1", "path2"]
+    assert result["exclude"] == ["test_*.py"]
+
+
 def test_invalid_config_options_output():
     """
     If the config file contains unknown options we want to abort.

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -100,6 +100,7 @@ def _parse_args(args=None):
         "paths",
         nargs="*",
         metavar="PATH",
+        default=missing,
         help="Paths may be Python files or directories. For each directory"
         " Vulture analyzes all contained *.py files.",
     )


### PR DESCRIPTION
The paths CLI argument did not use the default=missing sentinel, and so
returned an empty list if no paths were given to the CLI. This meant any
paths configured in pyproject.toml were overridden with an empty list,
making the path= setting useless.

Adding the sentinel to the CLI fixes this behaviour. A regression test
is also added to make sure TOML paths are used if no CLI paths are
given.

## Checklist:

- [X] I have updated the documentation in the README.md file or my changes don't require an update.
- [X] I have added an entry in CHANGELOG.md.
- [X] I have added or adapted tests to cover my changes.
