### PR TITLE
Issue #227, Feature/pathformat, adds --absolute-paths option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vulture.egg-info/
 .pytest_cache/
 .tox/
 .venv/
+.idea/

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ def test_cli_args():
         ignore_names=["name1", "name2"],
         make_whitelist=True,
         min_confidence=10,
+        absolute_paths=True,
         sort_by_size=True,
         verbose=True,
     )
@@ -39,6 +40,7 @@ def test_cli_args():
             "--min-confidence=10",
             "--sort-by-size",
             "--verbose",
+            "--absolute-paths",
             "path1",
             "path2",
         ]
@@ -97,6 +99,7 @@ def test_config_merging():
         min_confidence = 10
         sort_by_size = false
         verbose = false
+        absolute_paths = true
         paths = ["toml_path"]
         """
         )
@@ -108,6 +111,7 @@ def test_config_merging():
         "--make-whitelist",
         "--min-confidence=20",
         "--sort-by-size",
+        "--absolute-paths",
         "--verbose",
         "cli_path",
     ]
@@ -120,6 +124,7 @@ def test_config_merging():
         make_whitelist=True,
         min_confidence=20,
         sort_by_size=True,
+        absolute_paths=True,
         verbose=True,
     )
     assert result == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import ast
-import os
 import pathlib
 
 from vulture import utils
@@ -11,12 +10,14 @@ def check_paths(filename, absolute=False):
     pp = pathlib.PurePath(pathstr)
     check = pp.is_absolute()
     if absolute:
-        assert check == True
+        assert check
     # even if absolute == True, the path might have been specified absolute
     # so can't conclude negatively
 
+
 def test_absolute_path():
     check_paths(__file__, absolute=True)
+
 
 def test_relative_path():
     check_paths(__file__, absolute=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,25 @@
 import ast
+import os
+import pathlib
 
 from vulture import utils
+
+
+def check_paths(filename, absolute=False):
+    pathstr = utils.format_path(filename, absolute)
+    # platform dependencies and path types need to be accounted for
+    pp = pathlib.PurePath(pathstr)
+    check = pp.is_absolute()
+    if absolute:
+        assert check == True
+    # even if absolute == True, the path might have been specified absolute
+    # so can't conclude negatively
+
+def test_absolute_path():
+    check_paths(__file__, absolute=True)
+
+def test_relative_path():
+    check_paths(__file__, absolute=False)
 
 
 def check_decorator_names(code, expected_names):

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -20,7 +20,7 @@ DEFAULTS = {
     "make_whitelist": False,
     "sort_by_size": False,
     "verbose": False,
-    "absolute_paths": False
+    "absolute_paths": False,
 }
 
 

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -20,6 +20,7 @@ DEFAULTS = {
     "make_whitelist": False,
     "sort_by_size": False,
     "verbose": False,
+    "absolute_paths": False
 }
 
 
@@ -69,6 +70,7 @@ def _parse_toml(infile):
         make_whitelist = true
         min_confidence = 10
         sort_by_size = true
+        absolute_paths = false
         verbose = true
         paths = ["path1", "path2"]
     """
@@ -148,6 +150,13 @@ def _parse_args(args=None):
         action="store_true",
         default=missing,
         help="Sort unused functions and classes by their lines of code.",
+    )
+    parser.add_argument(
+        "--absolute-paths",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Output absolute file paths.",
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", default=missing

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -103,7 +103,7 @@ class Item:
         "last_lineno",
         "message",
         "confidence",
-        "absolute_paths"
+        "absolute_paths",
     )
 
     def __init__(
@@ -115,7 +115,7 @@ class Item:
         last_lineno,
         message="",
         confidence=DEFAULT_CONFIDENCE,
-        absolute_paths=False
+        absolute_paths=False,
     ):
         self.name = name
         self.typ = typ
@@ -174,10 +174,15 @@ class Vulture(ast.NodeVisitor):
     """Find dead code."""
 
     def __init__(
-        self, verbose=False, ignore_names=None, ignore_decorators=None, absolute_paths=False
+        self,
+        verbose=False,
+        ignore_names=None,
+        ignore_decorators=None,
+        absolute_paths=False,
     ):
         self.verbose = verbose
         self.absolute_paths = absolute_paths
+
         def get_list(typ):
             return utils.LoggingList(typ, self.verbose)
 
@@ -205,17 +210,21 @@ class Vulture(ast.NodeVisitor):
         self.filename = filename
 
         abs_paths = self.absolute_paths
+
         def handle_syntax_error(e):
             text = f' at "{e.text.strip()}"' if e.text else ""
             print(
-                f"{utils.format_path(filename, absolute=abs_paths)}:{e.lineno}: {e.msg}{text}",
+                f"{utils.format_path(filename, absolute=abs_paths)}:\
+{e.lineno}: {e.msg}{text}",
                 file=sys.stderr,
             )
             self.found_dead_code_or_error = True
 
         try:
             node = (
-                ast.parse(code, filename=self.filename, type_comments=True)  # fails if not python 3.8.x
+                ast.parse(
+                    code, filename=self.filename, type_comments=True
+                )  # fails if not python 3.8.x
                 if sys.version_info >= (3, 8)  # type_comments requires 3.8+
                 else ast.parse(code, filename=self.filename)
             )
@@ -224,7 +233,8 @@ class Vulture(ast.NodeVisitor):
         except ValueError as err:
             # ValueError is raised if source contains null bytes.
             print(
-                f'{utils.format_path(filename, absolute=self.absolute_paths)}: invalid source code "{err}"',
+                f'{utils.format_path(filename, absolute=self.absolute_paths)}: \
+                invalid source code "{err}"',
                 file=sys.stderr,
             )
             self.found_dead_code_or_error = True
@@ -456,7 +466,7 @@ class Vulture(ast.NodeVisitor):
                     last_lineno,
                     message=message,
                     confidence=confidence,
-                    absolute_paths=self.absolute_paths
+                    absolute_paths=self.absolute_paths,
                 )
             )
 
@@ -757,7 +767,7 @@ def main():
         verbose=config["verbose"],
         ignore_names=config["ignore_names"],
         ignore_decorators=config["ignore_decorators"],
-        absolute_paths=config["absolute_paths"]
+        absolute_paths=config["absolute_paths"],
     )
     vulture.scavenge(config["paths"], exclude=config["exclude"])
     sys.exit(

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -2,6 +2,7 @@ import ast
 import os
 import sys
 import tokenize
+from pathlib import Path
 
 
 class VultureInputException(Exception):
@@ -45,10 +46,20 @@ def condition_is_always_true(condition):
     return _safe_eval(condition, False)
 
 
-def format_path(path):
+def format_path(path, absolute=False):
     if not path:
         return path
-    relpath = os.path.relpath(path)
+    if not absolute:
+        relpath = os.path.relpath(path)
+        # print(f'relative path {relpath}', file=sys.stderr, flush=True)
+    else:
+        # print('absolute paths set', file=sys.stderr)
+        pp = Path(path)
+        # make the path absolute, resolving any symlinks
+        resolved_path = pp.resolve(strict=True)
+        # relpath = os.path.abspath(path)
+        relpath = str(resolved_path)
+        # print(f'abs path {relpath}', file=sys.stderr, flush=True)
     return relpath if not relpath.startswith("..") else path
 
 
@@ -96,7 +107,8 @@ class LoggingList(list):
     def __init__(self, typ, verbose):
         self.typ = typ
         self._verbose = verbose
-        return list.__init__(self)
+        # return list.__init__(self)
+        list.__init__(self)
 
     def append(self, item):
         if self._verbose:
@@ -108,7 +120,8 @@ class LoggingSet(set):
     def __init__(self, typ, verbose):
         self.typ = typ
         self._verbose = verbose
-        return set.__init__(self)
+        # return set.__init__(self)
+        set.__init__(self)
 
     def add(self, name):
         if self._verbose:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
by invoking with --absolute paths, output of problems found will specify file names in absolute path, platform-specific
when used with PyCharm, as an external tool, can now 'jump to code' on these messages by clicking on the file paths.

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [ ] I have updated the documentation in the README.md file or my changes don't require an update.
- [ ] I have added an entry in CHANGELOG.md.
- [ ] I have added or adapted tests to cover my changes.
