### PR TITLE
Print a success message to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Don't override paths in pyproject.toml with empty CLI paths (bcbnz, #228).
 * Run continuous integration tests for Python 3.9 (ju-sh, #232).
 * Use pathlib internally (ju-sh, #226).
+* Print a message to stdout on success (exhuma).
 
 # 2.1 (2020-08-19)
 

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -687,10 +687,11 @@ def main():
         ignore_decorators=config["ignore_decorators"],
     )
     vulture.scavenge(config["paths"], exclude=config["exclude"])
-    sys.exit(
-        vulture.report(
-            min_confidence=config["min_confidence"],
-            sort_by_size=config["sort_by_size"],
-            make_whitelist=config["make_whitelist"],
-        )
+    status = vulture.report(
+        min_confidence=config["min_confidence"],
+        sort_by_size=config["sort_by_size"],
+        make_whitelist=config["make_whitelist"],
     )
+    if status == 0:
+        print("Successfully finisehd. No unused code detected.")
+    sys.exit(status)


### PR DESCRIPTION
## Description

I usually run vulture in an auto re-running sub-shell, and because vulture neither prints a startup, nor a status-message on success I can never tell whether vulture has actually run or not.

This change adds a simple status message on successful run. I did not add a failure message because this is already covered by the normal printout from vulture.

At first I simply wrote ``done``, but made it a bit more verbose to make it more clear that the message comes from vulture. I was alternatively thinking of making it ``[vulture] done`` but I think the "normal/natural" English I used makes it more consistent with the exiting messages.

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [ ] I have added or adapted tests to cover my changes.
