### PR TITLE
Fix formatting of relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.4 (unreleased)
+
+* Print absolute filepaths as relative again (as with 2.1 and before) if they
+  are below the current directory. (The-Compiler, #246)
+
 # 2.3 (2021-01-16)
 
 * Add [pre-commit](https://pre-commit.com) hook (Clément Robert, #244).

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,43 @@
 import ast
+import os
+import pathlib
+
+import pytest
 
 from vulture import utils
+
+
+class TestFormatPath:
+    @pytest.fixture
+    def tmp_cwd(self, tmp_path, monkeypatch):
+        cwd = tmp_path / "workingdir"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        return cwd
+
+    def test_relative_inside(self):
+        filepath = pathlib.Path("testfile.py")
+        formatted = utils.format_path(filepath)
+        assert formatted == filepath
+        assert not formatted.is_absolute()
+
+    def test_relative_outside(self, tmp_cwd):
+        filepath = pathlib.Path(os.pardir) / "testfile.py"
+        formatted = utils.format_path(filepath)
+        assert formatted == filepath
+        assert not formatted.is_absolute()
+
+    def test_absolute_inside(self, tmp_cwd):
+        filepath = tmp_cwd / "testfile.py"
+        formatted = utils.format_path(filepath)
+        assert formatted == pathlib.Path("testfile.py")
+        assert not formatted.is_absolute()
+
+    def test_absolute_outside(self, tmp_cwd):
+        filepath = (tmp_cwd / os.pardir / "testfile.py").resolve()
+        formatted = utils.format_path(filepath)
+        assert formatted == filepath
+        assert formatted.is_absolute()
 
 
 def check_decorator_names(code, expected_names):

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -1,6 +1,6 @@
 import ast
-import sys
 import pathlib
+import sys
 import tokenize
 
 

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -1,6 +1,6 @@
 import ast
-import os
 import sys
+import pathlib
 import tokenize
 
 
@@ -47,7 +47,7 @@ def condition_is_always_true(condition):
 
 def format_path(path):
     try:
-        return path.relative_to(os.curdir)
+        return path.relative_to(pathlib.Path.cwd())
     except ValueError:
         # Path is not below the current directory.
         return path


### PR DESCRIPTION
Prior to vulture 2.2, it was possible to pass an absolute path below the current directory, and the report showed a relative path instead:

With vulture 2.1, inside `~/proj/qutebrowser/git/`:

```console
$ vulture ~/proj/qutebrowser/git/qutebrowser/qutebrowser.py
qutebrowser/qutebrowser.py:138: unused function 'directory' (60% confidence)
qutebrowser/qutebrowser.py:186: unused function 'main' (60% confidence)
```

With vulture 2.3:

```console
$ vulture ~/proj/qutebrowser/git/qutebrowser/qutebrowser.py
/home/florian/proj/qutebrowser/git/qutebrowser/qutebrowser.py:138: unused function 'directory' (60% confidence)
/home/florian/proj/qutebrowser/git/qutebrowser/qutebrowser.py:186: unused function 'main' (60% confidence)
```

This is due to #226, notably the `path.relative_to(os.curdir)` in `utils.format_path` - this won't work properly if the input is absolute:

```pycon
>>> import os, pathlib
>>> os.getcwd()
'/tmp'
>>> pathlib.Path('/tmp/somefile').relative_to('.')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.9/pathlib.py", line 928, in relative_to
    raise ValueError("{!r} is not in the subpath of {!r}"
ValueError: '/tmp/somefile' is not in the subpath of '' OR one path is relative and the other is absolute.
>>> pathlib.Path('/tmp/somefile').relative_to(pathlib.Path.cwd())
PosixPath('somefile')
```

## Checklist:

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.

cc @ju-sh
