### PR TITLE
Improve pytest invocation in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
   pytest
   pytest-cov
 commands =
-  py.test
+  pytest {posargs}
 
 [testenv:style]
 basepython = python3


### PR DESCRIPTION
This avoids the old py.test name (replaced by pytest in v3.0.0 in August
2016), and also makes it possible to pass arguments to pytest like so:

    tox -e py39 -- tests/test_utils.py

(checklist not really applicable)