### PR TITLE
Adding a python 3.10 trove

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [pypy3, 3.6, 3.7, 3.8, 3.9]
+        python-version: [pypy3, 3.6, 3.7, 3.8, 3.9, 3.10]
         os: [macos-10.15, ubuntu-18.04, ubuntu-20.04, windows-2019]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [pypy3, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['pypy3', '3.6', '3.7', '3.8', '3.9', '3.10']
         os: [macos-10.15, ubuntu-18.04, ubuntu-20.04, windows-2019]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 2.4 (unreleased)
 
 * Print absolute filepaths as relative again (as with 2.1 and before) if they
-  are below the current directory. (The-Compiler, #246)
-* Adding a python 3.10 trove for pypi. (chayim, #266).
+  are below the current directory (The-Compiler, #246).
+* Run tests and add PyPI trove for Python 3.10 (chayim, #266).
 
 # 2.3 (2021-01-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Print absolute filepaths as relative again (as with 2.1 and before) if they
   are below the current directory. (The-Compiler, #246)
+* Adding a python 3.10 trove for pypi. (chayim, #266).
 
 # 2.3 (2021-01-16)
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Quality Assurance",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cleanup, py{36,37,38,39}, style
+envlist = cleanup, py{36,37,38,39,310}, style
 skip_missing_interpreters = true
 
 # Erase old coverage results, then accumulate them during this tox run.


### PR DESCRIPTION
Added a python 3.10 trove for pypi - as I'm running this without issue in CI with 3.10.

- [X] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [ ] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
