### PR TITLE
Add support for `del` keyword for overridden functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Print absolute filepaths as relative again (as with 2.1 and before) if they
   are below the current directory (The-Compiler, #246).
 * Run tests and add PyPI trove for Python 3.10 (chayim, #266).
-* Add support for `del` keyword to mark variable as used for function/methods overrides (sshishov, #279)
+* Allow using the `del` keyword to mark unused variables (sshishov, #279).
 
 # 2.3 (2021-01-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Print absolute filepaths as relative again (as with 2.1 and before) if they
   are below the current directory (The-Compiler, #246).
 * Run tests and add PyPI trove for Python 3.10 (chayim, #266).
+* Add support for `del` keyword to mark variable as used for function/methods overrides (sshishov, #279)
 
 # 2.3 (2021-01-16)
 

--- a/README.md
+++ b/README.md
@@ -108,16 +108,20 @@ check that all whitelisted code actually still exists in your project.
 **Marking unused variables**
 
 There are situations where you can't just remove unused variables, e.g.,
-in tuple assignments or function signatures.
+in function signatures. The recommended solution is to use the `del`
+keyword as described in the
+[PyLint manual](http://pylint-messages.wikidot.com/messages:w0613) and on
+[StackOverflow](https://stackoverflow.com/a/14836005):
 
-The preferred way to solve this problem is to use `del` keyword. It is
-described in
-[PyLint manual](http://pylint-messages.wikidot.com/messages:w0613) and
-[StackOverflow](https://stackoverflow.com/a/14836005)
+```python
+def foo(x, y):
+    del y
+    return x + 3
+```
 
-Additionally, there is another way to solve it. Vulture will ignore these
-variables if they start with an underscore (e.g., `_x, y = get_pos()` or
-`def my_method(self, widget, **_kwargs)`).
+Vulture will also ignore all variables that start with an underscore, so
+you can use `_x, y = get_pos()` to mark unused tuple assignments or
+function arguments, e.g., `def foo(x, _y)`.
 
 **Minimum confidence**
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ check that all whitelisted code actually still exists in your project.
 **Marking unused variables**
 
 There are situations where you can't just remove unused variables, e.g.,
-in tuple assignments or function signatures. Vulture will ignore these
+in tuple assignments or function signatures.
+
+The preferred way to solve this problem is to use `del` keyword. It is
+described in
+[PyLint manual](http://pylint-messages.wikidot.com/messages:w0613) and
+[StackOverflow](https://stackoverflow.com/a/14836005)
+
+Additionally, there is another way to solve it. Vulture will ignore these
 variables if they start with an underscore (e.g., `_x, y = get_pos()` or
 `def my_method(self, widget, **_kwargs)`).
 

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -741,3 +741,21 @@ bad()
         assert not v.found_dead_code_or_error
     else:
         assert v.found_dead_code_or_error
+
+
+def test_unused_args_with_del(v):
+    v.scan(
+        """\
+def foo(a, b, c, d=3):
+    del c, d
+    return a + b
+
+foo(1, 2)
+"""
+    )
+
+    check(v.defined_funcs, ["foo"])
+    check(v.defined_vars, ["a", "b", "c", "d"])
+    check(v.used_names, ["foo", "a", "b", "c", "d"])
+    check(v.unused_vars, [])
+    check(v.unused_funcs, [])

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -609,7 +609,7 @@ class Vulture(ast.NodeVisitor):
 
     def visit_Name(self, node):
         if (
-            isinstance(node.ctx, ast.Load)
+            isinstance(node.ctx, (ast.Load, ast.Del))
             and node.id not in IGNORED_VARIABLE_NAMES
         ):
             self.used_names.add(node.id)


### PR DESCRIPTION
Currently if you override the function of any framework or any library and you are not using all parameters, then the parameters which are not used are identified as `unused`. It is good practice while overriding function/method to keep the signature of it intact. Otherwise you can get potentially some issues with next releases etc.

## Description
Adding support for `del` operation inside the function. The keyword `del` will mark the variable as used now and we can safely implement the suggested workaround.

## Related Issue
This PR is addressing the issue #278 

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
