### PR TITLE
Pass file names by default

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,4 @@
   entry: vulture
   description: Find unused Python code.
   types: [python]
-  pass_filenames: false
   require_serial: true
-  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* pass file names to `pre-commit` hook by default
+
 # 2.4 (2022-05-19)
 
 * Print absolute filepaths as relative again (as in version 2.1 and before)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ following to the `.pre-commit-config.yaml` file in your repository:
 ```yaml
 repos:
   - repo: https://github.com/jendrikseipp/vulture
-    rev: 'v2.3'  # or any later Vulture version
+    rev: 'v2.4'  # or any later Vulture version
     hooks:
       - id: vulture
 ```

--- a/README.md
+++ b/README.md
@@ -187,9 +187,21 @@ repos:
       - id: vulture
 ```
 
-Then run `pre-commit install`. Finally, create a `pyproject.toml` file
-in your repository and specify all files that Vulture should check under
-`[tool.vulture] --> paths` (see above).
+Then run `pre-commit install`, and it is set to run vulture on all
+python files in the repository.
+
+However, if it is needed to run `vulture` specifically on a subset of
+files, e.g. files configured under `[tool.vulture] --> paths` in the
+`pyproject.toml` (see above), set `pass_filenames` as `false` as below:
+
+```yaml
+repos:
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: 'v2.4'  # or any later Vulture version
+    hooks:
+      - id: vulture
+        pass_filenames: false
+```
 
 ## How does it work?
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Current hook definition stops passing file names as detected by `pre-commit`, and completely relies on the specifications in `pyproject.toml`.

Even though it's a good practice and quite common in python packages, I'd argue that end users (python developers using these packages) seldom configure with `pyproject.toml`. Their objective is just to run a tool to clean up the codebase as quickly as possible.

The changes in fork tries to resolve this by passing files from `pre-commit` by default (which is also the default for other standard linters - `pylint`, `flake8`, etc.).

If someone does configure vulture using `pyproject.toml`, they can still choose to use the current settings by defining paths in `pyproject.toml` and setting `pass_filenames` as `false`.

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->
resolves #280 

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file.
- [x] I have added an entry in CHANGELOG.md.
- [ ] I have added or adapted tests to cover my changes.
- [ ] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
