### PR TITLE
Mark imports in __all__ as used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Add whitelist for `pint.UnitRegistry.default_formatter` (Ben Elliston, #258).
+* Mark imports in `__all__` as used (kreathon, #172).
 
 # 2.4 (2022-05-19)
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -230,6 +230,72 @@ __all__ = ["Foo"]
     check(v.unused_imports, ["Bar"])
 
 
+def test_import_with__all__normal_reference(v):
+    v.scan(
+        """\
+# define.py
+class Foo:
+    pass
+
+class Bar:
+    pass
+
+# main.py
+from define import Foo, Bar
+
+__all__ = [Foo]
+
+"""
+    )
+    check(v.defined_imports, ["Foo", "Bar"])
+    check(v.unused_imports, ["Bar"])
+
+
+def test_import_with__all__string(v):
+    v.scan(
+        """\
+# define.py
+class Foo:
+    pass
+
+class Bar:
+    pass
+
+# main.py
+from define import Foo, Bar
+
+__all__ = "Foo"
+
+"""
+    )
+    check(v.defined_imports, ["Foo", "Bar"])
+    # __all__ is not a list or tuple, so Foo is unused.
+    check(v.unused_imports, ["Foo", "Bar"])
+
+
+def test_import_with__all__assign_other_module(v):
+    v.scan(
+        """\
+# define.py
+class Foo:
+    pass
+
+class Bar:
+    pass
+
+# main.py
+import define
+from define import Foo, Bar
+
+define.__all__ = ["Foo"]
+
+"""
+    )
+    check(v.defined_imports, ["define", "Foo", "Bar"])
+    # Only assignments to __all__ of the current module are covered.
+    check(v.unused_imports, ["Foo", "Bar"])
+
+
 def test_ignore_init_py_files(v):
     v.scan(
         """\

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -209,6 +209,27 @@ def test_import_alias_use_alias(v):
     check(v.unused_vars, [])
 
 
+def test_import_with__all__(v):
+    v.scan(
+        """\
+# define.py
+class Foo:
+    pass
+
+class Bar:
+    pass
+
+# main.py
+from define import Foo, Bar
+
+__all__ = ["Foo"]
+
+"""
+    )
+    check(v.defined_imports, ["Foo", "Bar"])
+    check(v.unused_imports, ["Bar"])
+
+
 def test_ignore_init_py_files(v):
     v.scan(
         """\

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -630,10 +630,8 @@ class Vulture(ast.NodeVisitor):
         if _assigns_special_variable__all__(node):
             assert isinstance(node.value, (ast.List, ast.Tuple))
             for elt in node.value.elts:
-                if isinstance(elt, ast.Constant) and isinstance(
-                    elt.value, str
-                ):
-                    self.used_names.add(elt.value)
+                if isinstance(elt, ast.Str):
+                    self.used_names.add(elt.s)
 
     def visit_While(self, node):
         self._handle_conditional_node(node, "while")

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -53,6 +53,16 @@ def _is_test_file(filename):
     )
 
 
+def _assigns_special_variable__all__(node):
+    assert isinstance(node, ast.Assign)
+    name_targets = {
+        target.id for target in node.targets if isinstance(target, ast.Name)
+    }
+    return "__all__" in name_targets and isinstance(
+        node.value, (ast.List, ast.Tuple)
+    )
+
+
 def _ignore_class(filename, class_name):
     return _is_test_file(filename) and "Test" in class_name
 
@@ -615,6 +625,15 @@ class Vulture(ast.NodeVisitor):
             self.used_names.add(node.id)
         elif isinstance(node.ctx, (ast.Param, ast.Store)):
             self._define_variable(node.id, node)
+
+    def visit_Assign(self, node):
+        if _assigns_special_variable__all__(node):
+            assert isinstance(node.value, (ast.List, ast.Tuple))
+            for elt in node.value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(
+                    elt.value, str
+                ):
+                    self.used_names.add(elt.value)
 
     def visit_While(self, node):
         self._handle_conditional_node(node, "while")

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -55,16 +55,10 @@ def _is_test_file(filename):
 
 def _assigns_special_variable__all__(node):
     assert isinstance(node, ast.Assign)
-    name_targets = {
-        target.id for target in node.targets if isinstance(target, ast.Name)
-    }
-    return "__all__" in name_targets and isinstance(
-        node.value, (ast.List, ast.Tuple)
-def _assigns_special_variable__all__(node):
-    assert isinstance(node, ast.Assign)
-    return (
-        isinstance(node.value, (ast.List, ast.Tuple)) and
-        any(target.id == "__all__" for target in node.targets if isinstance(target, ast.Name))
+    return isinstance(node.value, (ast.List, ast.Tuple)) and any(
+        target.id == "__all__"
+        for target in node.targets
+        if isinstance(target, ast.Name)
     )
 
 

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -60,6 +60,11 @@ def _assigns_special_variable__all__(node):
     }
     return "__all__" in name_targets and isinstance(
         node.value, (ast.List, ast.Tuple)
+def _assigns_special_variable__all__(node):
+    assert isinstance(node, ast.Assign)
+    return (
+        isinstance(node.value, (ast.List, ast.Tuple)) and
+        any(target.id == "__all__" for target in node.targets if isinstance(target, ast.Name))
     )
 
 


### PR DESCRIPTION
At the moment, symbols that are referenced in string form in the `__all__`  variable assignment are not marked as used.

#### Example

```
# Currently, 'Bar' would be marked as unused.
from foo import Bar

__all__ = ["Bar"]

```

## Implementation

Add `visit_Assign` to cover assignments of the following form:

```
# Default case
__all__ = ["A"]

# Tuples are also tolerated
__all__ = ("B", )
```

#### Limitations

The implementation cannot cover dynamic definitions e.g.:

```
a = ["A"]
__all__ = a
```


## Related Issue
This PR is addressing the issue https://github.com/jendrikseipp/vulture/issues/172.

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
