### PR TITLE
Fix get_decorator_name with callable in between

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.6 (Unreleased)
+
+* Fix `get_decorator_name` regression (Llandy3d, #285).
+
 # 2.5 (2022-07-03)
 
 * Mark imports in `__all__` as used (kreathon, #172, #282).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.6 (Unreleased)
 
-* Fix `get_decorator_name` regression (Llandy3d, #285).
+* Fix `get_decorator_name` with callable in between (Llandy3d, #285).
 
 # 2.5 (2022-07-03)
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,30 @@ makes Vulture ignore the `greet` method:
     dead_code.py:1: unused import 'os' (90% confidence)
     dead_code.py:8: unused variable 'message' (60% confidence)
 
+**Ignore decorators with callable in between**
+
+Consider the following Python script (`callable_decorator.py`):
+
+``` python
+@hist.labels('mylabel').time()
+def hello():
+    pass
+```
+
+Calling :
+
+    $ vulture callable_decorator.py
+
+results in the following output:
+
+    dead_code.py:1: unused function 'hello' (60% confidence)
+
+You can ignore the function decorated with the callable in between decorator with `--ignore-decorator`
+
+    $ vulture callable_decorator.py --ignore-decorator @hist.labels.time
+
+making Vulture ignore the `hello` function and resulting in no output.
+
 <!-- Hide noqa docs until we decide whether we want to support it.
 **Using "# noqa"**
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import ast
 import os
 import pathlib
+import sys
 
 import pytest
 
@@ -121,6 +122,9 @@ class Foo:
     check_decorator_names(code, ["@foo", "@bar.yz"])
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="requires python3.9 or higher"
+)
 def test_get_decorator_name_regression():
     code = """\
 from prometheus_client import Histogram

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,3 +119,14 @@ class Foo:
     pass
 """
     check_decorator_names(code, ["@foo", "@bar.yz"])
+
+
+def test_get_decorator_name_regression():
+    code = """\
+from prometheus_client import Histogram
+hist = Histogram("name", "description", labelsname=["label1"])
+@hist.labels("labelvalue").time()
+def myfunc():
+    pass
+"""
+    check_decorator_names(code, ["@hist.labels.time"])

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -54,12 +54,15 @@ def format_path(path):
 
 
 def get_decorator_name(decorator):
-    if isinstance(decorator, ast.Call):
-        decorator = decorator.func
     parts = []
-    while isinstance(decorator, ast.Attribute):
-        parts.append(decorator.attr)
-        decorator = decorator.value
+    while True:
+        if isinstance(decorator, ast.Call):
+            decorator = decorator.func
+        while isinstance(decorator, ast.Attribute):
+            parts.append(decorator.attr)
+            decorator = decorator.value
+        if not isinstance(decorator, ast.Call):
+            break
     parts.append(decorator.id)
     return "@" + ".".join(reversed(parts))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`get_decorator_name` would fail with an `AttributeError` on decorators on the style of the `prometheus_client` where you actually have a call in between instead of just at the end of it. Ex. `@hist.labels('label').time()`

This pr changes the method to loop so that we will catch all the `ast.Call` and can build the full name.

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->
https://github.com/jendrikseipp/vulture/issues/283

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
