### PR TITLE
Basic match statement support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Basic `match` statement support (kreathon, #276).
+
 # 2.5 (2022-07-03)
 
 * Mark imports in `__all__` as used (kreathon, #172, #282).

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 from . import check, v
 
 assert v  # Silence pyflakes.
@@ -759,3 +761,99 @@ foo(1, 2)
     check(v.used_names, ["foo", "a", "b", "c", "d"])
     check(v.unused_vars, [])
     check(v.unused_funcs, [])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="requires python3.10 or higher"
+)
+def test_match_class_simple(v):
+    v.scan(
+        """\
+from dataclasses import dataclass
+
+
+@dataclass
+class X:
+    a: int
+    b: int
+    c: int
+
+x = input()
+
+match x:
+    case X(a=0):
+        print("a")
+    case X(b=0, c=0):
+        print("b c")
+"""
+    )
+    check(v.defined_classes, ["X"])
+    check(v.defined_vars, ["a", "b", "c", "x"])
+
+    check(v.unused_classes, [])
+    check(v.unused_vars, [])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="requires python3.10 or higher"
+)
+def test_match_class_recursive(v):
+    v.scan(
+        """\
+from dataclasses import dataclass
+
+
+@dataclass
+class X:
+    a: int
+    b: int
+    c: int
+    d: int
+    e: int
+
+x = input()
+
+match x:
+    case X(a=1) | X(b=0):
+        print("Or")
+    case [X(c=1), X(d=0)]:
+        print("Sequence")
+    case {"k": X(e=1)}:
+        print("Mapping")
+"""
+    )
+    check(v.defined_classes, ["X"])
+    check(v.defined_vars, ["a", "b", "c", "d", "e", "x"])
+
+    check(v.unused_classes, [])
+    check(v.unused_vars, [])
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="requires python3.10 or higher"
+)
+def test_match_enum(v):
+    v.scan(
+        """\
+from enum import Enum
+
+
+class Color(Enum):
+    RED = 0
+    YELLOW = 1
+    GREEN = 1
+
+color = input()
+
+match color:
+    case Color.RED:
+        print("Real danger!")
+    case Color.YELLOW | Color.GREEN:
+        print("No danger!")
+"""
+    )
+    check(v.defined_classes, ["Color"])
+    check(v.defined_vars, ["RED", "YELLOW", "GREEN", "color"])
+
+    check(v.unused_classes, [])
+    check(v.unused_vars, [])

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -777,6 +777,7 @@ class X:
     a: int
     b: int
     c: int
+    u: int
 
 x = input()
 
@@ -791,13 +792,13 @@ match x:
     check(v.defined_vars, ["a", "b", "c", "x"])
 
     check(v.unused_classes, [])
-    check(v.unused_vars, [])
+    check(v.unused_vars, ["u"])
 
 
 @pytest.mark.skipif(
     sys.version_info < (3, 10), reason="requires python3.10 or higher"
 )
-def test_match_class_recursive(v):
+def test_match_class_embedded(v):
     v.scan(
         """\
 from dataclasses import dataclass
@@ -810,6 +811,7 @@ class X:
     c: int
     d: int
     e: int
+    u: int
 
 x = input()
 
@@ -826,7 +828,7 @@ match x:
     check(v.defined_vars, ["a", "b", "c", "d", "e", "x"])
 
     check(v.unused_classes, [])
-    check(v.unused_vars, [])
+    check(v.unused_vars, ["u"])
 
 
 @pytest.mark.skipif(
@@ -841,7 +843,8 @@ from enum import Enum
 class Color(Enum):
     RED = 0
     YELLOW = 1
-    GREEN = 1
+    GREEN = 2
+    BLUE = 3
 
 color = input()
 
@@ -856,4 +859,4 @@ match color:
     check(v.defined_vars, ["RED", "YELLOW", "GREEN", "color"])
 
     check(v.unused_classes, [])
-    check(v.unused_vars, [])
+    check(v.unused_vars, ["BLUE"])

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -789,7 +789,7 @@ match x:
 """
     )
     check(v.defined_classes, ["X"])
-    check(v.defined_vars, ["a", "b", "c", "x"])
+    check(v.defined_vars, ["a", "b", "c", "u", "x"])
 
     check(v.unused_classes, [])
     check(v.unused_vars, ["u"])
@@ -825,7 +825,7 @@ match x:
 """
     )
     check(v.defined_classes, ["X"])
-    check(v.defined_vars, ["a", "b", "c", "d", "e", "x"])
+    check(v.defined_vars, ["a", "b", "c", "d", "e", "u", "x"])
 
     check(v.unused_classes, [])
     check(v.unused_vars, ["u"])
@@ -856,7 +856,7 @@ match color:
 """
     )
     check(v.defined_classes, ["Color"])
-    check(v.defined_vars, ["RED", "YELLOW", "GREEN", "color"])
+    check(v.defined_vars, ["RED", "YELLOW", "GREEN", "BLUE", "color"])
 
     check(v.unused_classes, [])
     check(v.unused_vars, ["BLUE"])

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -635,6 +635,10 @@ class Vulture(ast.NodeVisitor):
     def visit_While(self, node):
         self._handle_conditional_node(node, "while")
 
+    def visit_MatchClass(self, node):
+        for kwd_attr in node.kwd_attrs:
+            self.used_names.add(kwd_attr)
+
     def visit(self, node):
         method = "visit_" + node.__class__.__name__
         visitor = getattr(self, method, None)

--- a/vulture/whitelists/ast_whitelist.py
+++ b/vulture/whitelists/ast_whitelist.py
@@ -39,6 +39,7 @@ whitelist_node_visitor.visit_Interactive
 whitelist_node_visitor.visit_Lambda
 whitelist_node_visitor.visit_List
 whitelist_node_visitor.visit_ListComp
+whitelist_node_visitor.visit_MatchClass
 whitelist_node_visitor.visit_Module
 whitelist_node_visitor.visit_Name
 whitelist_node_visitor.visit_NameConstant


### PR DESCRIPTION

#### Example



```
@dataclass
class X:
    a: int

x = input()

match x:
    case X(a=0):
        ...
    case _:
        ...
```

At the moment, `a` would be seen as unused. However, as nicely described by @exoriente, the code means something like

```
    if is_instance(x, X) and x.a == 0:
```

So it is not a normal / dead "assignment" and `a` should not be seen as unused.

## Implementation
The actual code change is really trivial, since most of the desired behavior (for the match statement) is already handled by `visit_Name`:

```
    def visit_MatchClass(self, node):
        for kwd_attr in node.kwd_attrs:
            self.used_names.add(kwd_attr)
```

#### Limitations
- cannot handle positional arguments (can be tricky since overwrites of `__match_args__` are possible)
- cannot handle variable definitions in `case`: e.g. "case [1, a, *rest]" (`a` and `rest` is not handled i.e. checked if it is used in the case body). Currently, I do not see any problem implementing it in the future.

#### Python Compatibility

For Python < 3.10 the `visit_MatchClass` should never be executed. Tests are guarded with `@pytest.mark.skipif(
    sys.version_info < (3, 10), ...)`

## Related Issue
This PR is addressing the issue https://github.com/jendrikseipp/vulture/issues/276.

## Checklist:

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
