### PR TITLE
Adding a new option --exit-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ codes.
 |     1     | Invalid input (file missing, syntax error, wrong encoding)    |
 |     2     | Invalid command line arguments                                |
 
+**Note:** If you set `--exit-zero`, Vulture will always return 0, which may be 
+helpful if you use it in continuous integration scripts.
+
 ## Similar programs
 
   - [pyflakes](https://pypi.org/project/pyflakes/) finds unused imports

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,7 @@ def test_toml_config():
         min_confidence=10,
         sort_by_size=True,
         verbose=True,
+        exit_zero=True,
     )
     data = StringIO(
         dedent(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ def test_cli_args():
         min_confidence=10,
         sort_by_size=True,
         verbose=True,
+        exit_zero=True,
     )
     result = _parse_args(
         [
@@ -39,6 +40,7 @@ def test_cli_args():
             "--min-confidence=10",
             "--sort-by-size",
             "--verbose",
+            "--exit-zero",
             "path1",
             "path2",
         ]
@@ -72,6 +74,7 @@ def test_toml_config():
         min_confidence = 10
         sort_by_size = true
         verbose = true
+        exit_zero = true
         paths = ["path1", "path2"]
         """
         )
@@ -97,6 +100,7 @@ def test_config_merging():
         min_confidence = 10
         sort_by_size = false
         verbose = false
+        exit_zero = false
         paths = ["toml_path"]
         """
         )
@@ -109,6 +113,7 @@ def test_config_merging():
         "--min-confidence=20",
         "--sort-by-size",
         "--verbose",
+        "--exit-zero",
         "cli_path",
     ]
     result = make_config(cliargs, toml)
@@ -121,6 +126,7 @@ def test_config_merging():
         min_confidence=20,
         sort_by_size=True,
         verbose=True,
+        exit_zero=True,
     )
     assert result == expected
 

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -19,6 +19,7 @@ DEFAULTS = {
     "ignore_names": [],
     "make_whitelist": False,
     "sort_by_size": False,
+    "exit_zero": False,
     "verbose": False,
 }
 
@@ -149,6 +150,14 @@ def _parse_args(args=None):
         action="store_true",
         default=missing,
         help="Sort unused functions and classes by their lines of code.",
+    )
+    parser.add_argument(
+        "--exit-zero",
+        action="store_true",
+        default=missing,
+        help="Always return a 0 (non-error) status code,"
+        " even if Vulture errors are found."
+        " This is primarily useful in continuous integration scripts.",
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", default=missing

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -707,10 +707,9 @@ def main():
         ignore_decorators=config["ignore_decorators"],
     )
     vulture.scavenge(config["paths"], exclude=config["exclude"])
-    sys.exit(
-        vulture.report(
-            min_confidence=config["min_confidence"],
-            sort_by_size=config["sort_by_size"],
-            make_whitelist=config["make_whitelist"],
-        )
+    report_code = vulture.report(
+        min_confidence=config["min_confidence"],
+        sort_by_size=config["sort_by_size"],
+        make_whitelist=config["make_whitelist"],
     )
+    sys.exit(report_code if not config["exit_zero"] else 0)


### PR DESCRIPTION
Related tools, like pylint and flake8, have similar options to make the program always return zero so that the tool can be easily integrated into continuous integration pipelines.