### PR TITLE
Add `UnicodeEncodeError` exception handling to `core.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `UnicodeEncodeError` exception handling to `core.py` (milanbalazs, #299).
+
 # 2.7 (2023-01-08)
 
 * Ignore `setup_module()`, `teardown_module()`, etc. in pytest `test_*.py` files (Jendrik Seipp).

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -14,6 +14,7 @@ class Foo:
     def bar(self):
         self.foobar = "unused attribute"
         foobar = "unused variable"
+        日本人 = "unused variable"
         return
         print("unreachable")
 
@@ -46,9 +47,10 @@ def test_item_report(check_report):
 {filename}:7: unused method 'bar' (60% confidence)
 {filename}:8: unused attribute 'foobar' (60% confidence)
 {filename}:9: unused variable 'foobar' (60% confidence)
-{filename}:11: unreachable code after 'return' (100% confidence)
-{filename}:13: unused property 'myprop' (60% confidence)
-{filename}:17: unused function 'myfunc' (60% confidence)
+{filename}:10: unused variable '\u65e5\u672c\u4eba' (60% confidence)
+{filename}:12: unreachable code after 'return' (100% confidence)
+{filename}:14: unused property 'myprop' (60% confidence)
+{filename}:18: unused function 'myfunc' (60% confidence)
 """
     check_report(mock_code, expected)
 
@@ -60,8 +62,9 @@ Foo  # unused class ({filename}:3)
 _.bar  # unused method ({filename}:7)
 _.foobar  # unused attribute ({filename}:8)
 foobar  # unused variable ({filename}:9)
-# unreachable code after 'return' ({filename}:11)
-_.myprop  # unused property ({filename}:13)
-myfunc  # unused function ({filename}:17)
+\u65e5\u672c\u4eba  # unused variable ({filename}:10)
+# unreachable code after 'return' ({filename}:12)
+_.myprop  # unused property ({filename}:14)
+myfunc  # unused function ({filename}:18)
 """
     check_report(mock_code, expected, make_whitelist=True)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from . import v
 
@@ -32,7 +33,8 @@ def check_report(v, capsys):
         filename = "foo.py"
         v.scan(code, filename=filename)
         capsys.readouterr()
-        v.report(make_whitelist=make_whitelist)
+        ret = v.report(make_whitelist=make_whitelist)
+        assert ret
         assert capsys.readouterr().out == expected.format(filename=filename)
 
     return test_report

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,4 @@
 import pytest
-import sys
 
 from . import v
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -40,6 +40,12 @@ def check_report(v, capsys):
     return test_report
 
 
+def test_logging(v, capsys):
+    expected = "\u65e5\u672c\u4eba\xc0\n"
+    v._log("日本人À")
+    assert capsys.readouterr().out == expected
+
+
 def test_item_report(check_report):
     expected = """\
 {filename}:1: unused import 'foo' (90% confidence)

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -384,13 +384,23 @@ class Vulture(ast.NodeVisitor):
     def unused_attrs(self):
         return _get_unused_items(self.defined_attrs, self.used_names)
 
-    def _log(self, *args, file=sys.stdout, force=False):
+    def _log(self, *args, file=None, force=False):
         if self.verbose or force:
             try:
-                print(*args, file=file)
+                # NOTE:
+                # The above if condition is needed because if I redirect the print directly to the
+                # sys.stdout then PyTest will be failed because it cannot captures the STDOUT.
+                # So the default "sys.stdout" value of "file" Kwarg doesn't work in this case.
+                if file:
+                    print(*args, file=file)
+                else:
+                    print(*args)
             except UnicodeEncodeError:
                 x = " ".join(map(str, args))
-                print(x.encode(), file=file)
+                if file:
+                    print(x.encode(), file=file)
+                else:
+                    print(x.encode())
 
     def _add_aliases(self, node):
         """

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -388,9 +388,12 @@ class Vulture(ast.NodeVisitor):
         if self.verbose or force:
             try:
                 # NOTE:
-                # The above if condition is needed because if I redirect the print directly to the
-                # sys.stdout then PyTest will be failed because it cannot captures the STDOUT.
-                # So the default "sys.stdout" value of "file" Kwarg doesn't work in this case.
+                # The above if condition is needed because if
+                # I redirect the print directly to the
+                # sys.stdout then PyTest will be failed because
+                # it cannot captures the STDOUT.
+                # So the default "sys.stdout" value of "file"
+                # Kwarg doesn't work in this case.
                 if file:
                     print(*args, file=file)
                 else:

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -387,23 +387,10 @@ class Vulture(ast.NodeVisitor):
     def _log(self, *args, file=None, force=False):
         if self.verbose or force:
             try:
-                # NOTE:
-                # The above if condition is needed because if
-                # I redirect the print directly to the
-                # sys.stdout then PyTest will be failed because
-                # it cannot captures the STDOUT.
-                # So the default "sys.stdout" value of "file"
-                # Kwarg doesn't work in this case.
-                if file:
-                    print(*args, file=file)
-                else:
-                    print(*args)
+                print(*args, file=file if file else sys.stdout)
             except UnicodeEncodeError:
                 x = " ".join(map(str, args))
-                if file:
-                    print(x.encode(), file=file)
-                else:
-                    print(x.encode())
+                print(x.encode(), file=file if file else sys.stdout)
 
     def _add_aliases(self, node):
         """

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -11,22 +11,9 @@ from vulture import noqa
 from vulture import utils
 from vulture.config import make_config
 
-
 DEFAULT_CONFIDENCE = 60
 
 IGNORED_VARIABLE_NAMES = {"object", "self"}
-PYTEST_FUNCTION_NAMES = {
-    "setup_module",
-    "teardown_module",
-    "setup_function",
-    "teardown_function",
-}
-PYTEST_METHOD_NAMES = {
-    "setup_class",
-    "teardown_class",
-    "setup_method",
-    "teardown_method",
-}
 
 ERROR_CODES = {
     "attribute": "V101",
@@ -88,16 +75,12 @@ def _ignore_import(filename, import_name):
 
 
 def _ignore_function(filename, function_name):
-    return (
-        function_name in PYTEST_FUNCTION_NAMES
-        or function_name.startswith("test_")
-    ) and _is_test_file(filename)
+    return function_name.startswith("test_") and _is_test_file(filename)
 
 
 def _ignore_method(filename, method_name):
     return _is_special_name(method_name) or (
-        (method_name in PYTEST_METHOD_NAMES or method_name.startswith("test_"))
-        and _is_test_file(filename)
+        method_name.startswith("test_") and _is_test_file(filename)
     )
 
 
@@ -227,7 +210,7 @@ class Vulture(ast.NodeVisitor):
 
         def handle_syntax_error(e):
             text = f' at "{e.text.strip()}"' if e.text else ""
-            print(
+            self._log(
                 f"{utils.format_path(filename)}:{e.lineno}: {e.msg}{text}",
                 file=sys.stderr,
             )
@@ -245,9 +228,10 @@ class Vulture(ast.NodeVisitor):
             handle_syntax_error(err)
         except ValueError as err:
             # ValueError is raised if source contains null bytes.
-            print(
+            self._log(
                 f'{utils.format_path(filename)}: invalid source code "{err}"',
                 file=sys.stderr,
+                force=True,
             )
             self.found_dead_code_or_error = True
         else:
@@ -279,10 +263,11 @@ class Vulture(ast.NodeVisitor):
             try:
                 module_string = utils.read_file(module)
             except utils.VultureInputException as err:  # noqa: F841
-                print(
+                self._log(
                     f"Error: Could not read file {module} - {err}\n"
                     f"Try to change the encoding to UTF-8.",
                     file=sys.stderr,
+                    force=True,
                 )
                 self.found_dead_code_or_error = True
             else:
@@ -344,10 +329,11 @@ class Vulture(ast.NodeVisitor):
         for item in self.get_unused_code(
             min_confidence=min_confidence, sort_by_size=sort_by_size
         ):
-            print(
+            self._log(
                 item.get_whitelist_string()
                 if make_whitelist
-                else item.get_report(add_size=sort_by_size)
+                else item.get_report(add_size=sort_by_size),
+                force=True,
             )
             self.found_dead_code_or_error = True
         return self.found_dead_code_or_error
@@ -380,9 +366,13 @@ class Vulture(ast.NodeVisitor):
     def unused_attrs(self):
         return _get_unused_items(self.defined_attrs, self.used_names)
 
-    def _log(self, *args):
-        if self.verbose:
-            print(*args)
+    def _log(self, *args, file=sys.stdout, force=False):
+        if self.verbose or force:
+            try:
+                print(*args, file=file)
+            except UnicodeEncodeError:
+                x = " ".join(map(str, args))
+                print(x.encode(), file=file)
 
     def _add_aliases(self, node):
         """
@@ -650,10 +640,6 @@ class Vulture(ast.NodeVisitor):
 
     def visit_While(self, node):
         self._handle_conditional_node(node, "while")
-
-    def visit_MatchClass(self, node):
-        for kwd_attr in node.kwd_attrs:
-            self.used_names.add(kwd_attr)
 
     def visit(self, node):
         method = "visit_" + node.__class__.__name__


### PR DESCRIPTION
## Description

If the code contains special characters which are not part of the `latin-1` codec, the `print` function will be failed with an `UnicodeEncodeError` exception. Like below: 

```
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 84-90: ordinal not in range(256)
```

If the string is encoded (default is `utf-8`) then the print function is able to print the related string. The users can identify the related file and line.

**An example output with my change:**

```
b"test.py:6: unused variable '\xd0\xb2\xd0\x82\xd0\x87' (60% confidence)"
```

**Note:**

 - My change doesn't change the original behavior and it's totally backward compatible. 

## Related Issue

- https://github.com/jendrikseipp/vulture/issues/299

## Checklist:

- [✅] I have updated the documentation in the README.md file or my changes don't require an update.
- [✅] I have added an entry in CHANGELOG.md.
- [✅] I have added or adapted tests to cover my changes.
- [✅] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
