### PR TITLE
Add the ability to use the full path for exclude folder/file

### DIFF
--- a/vulture/core.py
+++ b/vulture/core.py
@@ -2,6 +2,7 @@ import ast
 from fnmatch import fnmatch, fnmatchcase
 from pathlib import Path
 import pkgutil
+import os
 import re
 import string
 import sys
@@ -261,6 +262,11 @@ class Vulture(ast.NodeVisitor):
 
     def scavenge(self, paths, exclude=None):
         def prepare_pattern(pattern):
+            if pattern.startswith('./') is True:
+                pattern = os.path.abspath(pattern)
+                if os.path.isfile(pattern) is False:
+                    pattern = f"{pattern}/*"
+                return pattern
             if not any(char in pattern for char in "*?["):
                 pattern = f"*{pattern}*"
             return pattern


### PR DESCRIPTION
## Description
**AS-IS:**
```bash
vulture . --exclude=scripts,app.py  # run command
```
*Vulture* exclude all folders/files with match `*scripts*` or `*app.py*` and no way to specify the exact location of the object.

**TO-BE:**
```bash
vulture . --exclude=./scripts,./app.py  # run command
```
Now *vulture* adding `./ ` to exclude will determine the full path to the object:
```python
['/Users/<name>/Desktop/folder/scripts/*', '/Users/<name>/Desktop/folder/app.py'
```


## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
