### PR TITLE
Fix false positives in typing.Protocol

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade build coveralls setuptools tox==4.0.2 wheel ast-scope=0.3.1
+        python -m pip install --upgrade build coveralls setuptools tox==4.0.2 wheel ast-scope==0.3.1
 
     - name: Build Vulture wheel
       run: python -m build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade build coveralls setuptools tox==4.0.2 wheel
+        python -m pip install --upgrade build coveralls setuptools tox==4.0.2 wheel ast-scope=0.3.1
 
     - name: Build Vulture wheel
       run: python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Add `UnicodeEncodeError` exception handling to `core.py` (milanbalazs, #299).
 * Add whitelist for `Enum` attributes `_name_` and `_value_` (Eugene Toder, #305).
+* Add scoping info to handle false positives with `typing.Protocol` (pm3512, #309).
 
 # 2.7 (2023-01-08)
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    install_requires=["toml"],
+    install_requires=["toml", "ast_scope"],
     entry_points={"console_scripts": ["vulture = vulture.core:main"]},
     python_requires=">=3.6",
     packages=setuptools.find_packages(exclude=["tests"]),

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -899,3 +899,28 @@ match color:
 
     check(v.unused_classes, [])
     check(v.unused_vars, ["BLUE"])
+
+
+def test_protocol(v):
+    v.scan(
+        """\
+from typing import Protocol, Mapping
+
+class LoggerProtocol(Protocol):
+    def log(
+        self,
+        level: int,
+        msg: str,
+        *args,
+        extra: Mapping[str, object] | None = None
+    ) -> None:
+        ...
+
+    def foo(self) -> None:
+        ...
+"""
+    )
+
+    check(v.unused_vars, [])
+    check(v.unused_funcs, [])
+    check(v.unused_classes, ["LoggerProtocol"])

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -600,8 +600,7 @@ class Vulture(ast.NodeVisitor):
     @staticmethod
     def _is_subclass(node, class_name):
         """Return True if the node is a subclass of the given class."""
-        if not isinstance(node, ast.ClassDef):
-            return False
+        assert isinstance(node, ast.ClassDef)
         for superclass in node.bases:
             if (
                 isinstance(superclass, ast.Name)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds the `ast_scope` package and uses scoping information to find functions in subclasses of `typing.Protocol` and mark them and their arguments as used.
## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
Resolves #309
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
