### PR TITLE
Swap in tomllib/tomli for toml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vulture.egg-info/
 .pytest_cache/
 .tox/
 .venv/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 2.11 (2023-11-13)
-* Switch to tomllib/tomli to support heterogenous arrays. (Sebastian Csar, #340)
+# next (unreleased)
+* Switch to tomllib/tomli to support heterogeneous arrays (Sebastian Csar, #340).
 
 # 2.10 (2023-10-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.11 (2023-11-13)
+* Switch to tomllib/tomli to support heterogenous arrays. (Sebastian Csar, #340)
+
 # 2.10 (2023-10-06)
 
 * Drop support for Python 3.7 (Jendrik Seipp, #323).

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    install_requires=["toml"],
+    install_requires=["tomli >= 1.1.0; python_version < '3.11'"],
     entry_points={"console_scripts": ["vulture = vulture.core:main"]},
     python_requires=">=3.8",
     packages=setuptools.find_packages(exclude=["tests"]),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,13 @@ from vulture.config import (
 )
 
 
+def get_toml_bytes(toml_str: str) -> BytesIO:
+    """
+    Wrap a string in BytesIO to play the role of the incoming config stream.
+    """
+    return BytesIO(bytes(toml_str, "utf-8"))
+
+
 def test_cli_args():
     """
     Ensure that CLI arguments are converted to a config object.
@@ -62,10 +69,9 @@ def test_toml_config():
         sort_by_size=True,
         verbose=True,
     )
-    data = BytesIO(
-        bytes(
-            dedent(
-                """\
+    data = get_toml_bytes(
+        dedent(
+            """\
         [tool.vulture]
         exclude = ["file*.py", "dir/"]
         ignore_decorators = ["deco1", "deco2"]
@@ -76,8 +82,6 @@ def test_toml_config():
         verbose = true
         paths = ["path1", "path2"]
         """
-            ),
-            "utf-8",
         )
     )
     result = _parse_toml(data)
@@ -100,10 +104,9 @@ def test_toml_config_with_heterogenous_array():
         sort_by_size=True,
         verbose=True,
     )
-    data = BytesIO(
-        bytes(
-            dedent(
-                """\
+    data = get_toml_bytes(
+        dedent(
+            """\
         [tool.foo]
         # comment for good measure
         problem_array = [{a = 1}, [2,3,4], "foo"]
@@ -118,8 +121,6 @@ def test_toml_config_with_heterogenous_array():
         verbose = true
         paths = ["path1", "path2"]
         """
-            ),
-            "utf-8",
         )
     )
     result = _parse_toml(data)
@@ -132,10 +133,9 @@ def test_config_merging():
     If we have both CLI args and a ``pyproject.toml`` file, the CLI args should
     have precedence.
     """
-    toml = BytesIO(
-        bytes(
-            dedent(
-                """\
+    toml = get_toml_bytes(
+        dedent(
+            """\
         [tool.vulture]
         exclude = ["toml_exclude"]
         ignore_decorators = ["toml_deco"]
@@ -146,8 +146,6 @@ def test_config_merging():
         verbose = false
         paths = ["toml_path"]
         """
-            ),
-            "utf-8",
         )
     )
     cliargs = [
@@ -179,16 +177,13 @@ def test_config_merging_missing():
     If we have set a boolean value in the TOML file, but not on the CLI, we
     want the TOML value to be taken.
     """
-    toml = BytesIO(
-        bytes(
-            dedent(
-                """\
+    toml = get_toml_bytes(
+        dedent(
+            """\
         [tool.vulture]
         verbose = true
         ignore_names = ["name1"]
         """
-            ),
-            "utf-8",
         )
     )
     cliargs = [
@@ -204,15 +199,12 @@ def test_config_merging_toml_paths_only():
     If we have paths in the TOML but not on the CLI, the TOML paths should be
     used.
     """
-    toml = BytesIO(
-        bytes(
-            dedent(
-                """\
+    toml = get_toml_bytes(
+        dedent(
+            """\
         [tool.vulture]
         paths = ["path1", "path2"]
         """
-            ),
-            "utf-8",
         )
     )
     cliargs = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,7 +106,7 @@ def test_toml_config_with_heterogenous_array():
                 """\
         [tool.foo]
         # comment for good measure
-        problem_array = [{ a = 1}, [2,3,4], "foo"]
+        problem_array = [{a = 1}, [2,3,4], "foo"]
 
         [tool.vulture]
         exclude = ["file*.py", "dir/"]

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -5,7 +5,10 @@ command-line arguments or the pyproject.toml file.
 import argparse
 import pathlib
 
-import toml
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 from .version import __version__
 
@@ -76,7 +79,7 @@ def _parse_toml(infile):
         verbose = true
         paths = ["path1", "path2"]
     """
-    data = toml.load(infile)
+    data = tomllib.load(infile)
     settings = data.get("tool", {}).get("vulture", {})
     _check_input_config(settings)
     return settings
@@ -194,7 +197,7 @@ def make_config(argv=None, tomlfile=None):
     else:
         toml_path = pathlib.Path("pyproject.toml").resolve()
         if toml_path.is_file():
-            with open(toml_path) as fconfig:
+            with open(toml_path, "rb") as fconfig:
                 config = _parse_toml(fconfig)
             detected_toml_path = str(toml_path)
         else:


### PR DESCRIPTION
## Description

Fixes #339 -- the toml package does not support heterogenous arrays, which are now allowed in the toml spec. This commit swaps in tomllib from the standard library for Python >= 3.11 and its backport tomli for older versions.

## Checklist:
- [X] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [X] I have added or adapted tests to cover my changes.
- [X] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
