### PR TITLE
chore: Bump flake8, flake8-comprehensions and flake8-bugbear.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         exclude: rednotebook/external/.*\.py
 
   - repo: https://github.com/pycqa/flake8
-    rev: '6.0.0'
+    rev: '6.1.0'
     hooks:
       - id: flake8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # next (unreleased)
+* Bump flake8, flake8-comprehensions and flake8-bugbear. (Sebastian Csar,
+#341).
 * Switch to tomllib/tomli to support heterogeneous arrays (Sebastian Csar, #340).
 
 # 2.10 (2023-10-06)

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,10 @@ filterwarnings =
 basepython = python3
 deps =
   black==22.3.0
-  flake8==6.0.0
+  flake8==6.1.0
   flake8-2020==1.7.0
-  flake8-bugbear==23.1.14
-  flake8-comprehensions==3.10.1
+  flake8-bugbear==23.9.16
+  flake8-comprehensions==3.14.0
   pyupgrade==2.28.0
 allowlist_externals =
   bash


### PR DESCRIPTION
## Description

flake8 version 6.0.0 had a bug that lead to false positives for E231 in Python 3.12 which was fixed in 6.1.0. This commit bumps flake8 to 6.1.0, flake8-comprehensions to 3.14.0, to pick up explicit support for Python 3.12, and flake8-bugbear to 23.9.16 to pick up support for 3.12 and a bugfix.

## Checklist:

- [X] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [X] I have added or adapted tests to cover my changes.
- [X] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
