### PR TITLE
Provide whitelist parity for `MagicMock` and `Mock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # next (unreleased)
-* Bump flake8, flake8-comprehensions and flake8-bugbear. (Sebastian Csar,
-#341).
+* Bump flake8, flake8-comprehensions and flake8-bugbear (Sebastian Csar, #341).
 * Switch to tomllib/tomli to support heterogeneous arrays (Sebastian Csar, #340).
+* Provide whitelist parity for `MagicMock` and `Mock` (maxrake).
 
 # 2.10 (2023-10-06)
 

--- a/vulture/whitelists/unittest_whitelist.py
+++ b/vulture/whitelists/unittest_whitelist.py
@@ -14,3 +14,6 @@ TestCase.subTest
 
 mock.Mock.return_value
 mock.Mock.side_effect
+
+mock.MagicMock.return_value
+mock.MagicMock.side_effect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There are whitelist entries for the `return_value` and `side_effect`
attributes of the `unittest.mock.Mock` class. This change seeks to
provide parity for the `unittest.mock.MagicMock` class, which is just a
subclass of `Mock` but with default implementations of most of the magic
methods.

Standard library reference:
https://docs.python.org/3/library/unittest.mock.html#magic-mock

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] ~I have added or adapted tests to cover my changes.~
  - No whitelist tests were found to update
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
