### PR TITLE
Read exclude patterns from .gitignore in absence of user-provided patterns (#344)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       run: python -m pip wheel .
 
     - name: Install wheels
-      run: python -m pip install --find-links=. *
+      run: python -m pip install --find-links=. *.whl
 
     - name: Run Vulture
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,11 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade build coveralls setuptools tox wheel
 
-    - name: Build Vulture wheel
-      run: python -m build
+    - name: Build wheels for Vulture and its dependencies
+      run: python -m pip wheel .
 
-    - name: Install Vulture wheel
-      run: "python -m pip install --only-binary=:all: --ignore-installed --find-links=dist/ vulture"
+    - name: Install wheels
+      run: python -m pip install *.whl
 
     - name: Run Vulture
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       run: python -m pip wheel .
 
     - name: Install wheels
-      run: python -m pip install *
+      run: "python -m pip install *.whl"
 
     - name: Run Vulture
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       run: python -m pip wheel .
 
     - name: Install wheels
-      run: "python -m pip install *.whl"
+      run: python -m pip install --find-links=. *
 
     - name: Run Vulture
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,12 +31,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade build coveralls setuptools tox wheel
+        python -m pip install -r requirements.txt
 
-    - name: Build wheels for Vulture and its dependencies
-      run: python -m pip wheel .
+    - name: Build Vulture wheel
+      run: python -m build
 
-    - name: Install wheels
-      run: python -m pip install --find-links=. *.whl
+    - name: Install Vulture wheel
+      run: "python -m pip install --only-binary=:all: --ignore-installed --find-links=dist/ vulture"
 
     - name: Run Vulture
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       run: python -m pip wheel .
 
     - name: Install wheels
-      run: python -m pip install *.whl
+      run: python -m pip install *
 
     - name: Run Vulture
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Bump flake8, flake8-comprehensions and flake8-bugbear (Sebastian Csar, #341).
 * Switch to tomllib/tomli to support heterogeneous arrays (Sebastian Csar, #340).
 * Provide whitelist parity for `MagicMock` and `Mock` (maxrake).
+* Use .gitignore to exclude files if --exclude is missing from both pyproject.toml and the command line.
 
 # 2.10 (2023-10-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Bump flake8, flake8-comprehensions and flake8-bugbear (Sebastian Csar, #341).
 * Switch to tomllib/tomli to support heterogeneous arrays (Sebastian Csar, #340).
 * Provide whitelist parity for `MagicMock` and `Mock` (maxrake).
-* Use .gitignore to exclude files if --exclude is missing from both pyproject.toml and the command line.
+* Use .gitignore to exclude files if --exclude is missing from both pyproject.toml and the command line (whosayn, #344, #345).
 
 # 2.10 (2023-10-06)
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ If you want to ignore a whole file or directory, use the `--exclude` parameter
 (e.g., `--exclude "*settings.py,*/docs/*.py,*/test_*.py,*/.venv/*.py"`). The
 exclude patterns are matched against absolute paths.
 
+Note that releases after 2.10 will parse the project's .gitignore files for
+exclude patterns if the `--exclude` parameter is unused and if there are no
+exclude patterns in the pyproject.toml file.
+
 #### Flake8 noqa comments
 
 <!-- Hide noqa docs until we decide whether we want to support it.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you want to ignore a whole file or directory, use the `--exclude` parameter
 (e.g., `--exclude "*settings.py,*/docs/*.py,*/test_*.py,*/.venv/*.py"`). The
 exclude patterns are matched against absolute paths.
 
-Note that releases after 2.10 will parse the project's .gitignore files for
+Vulture 2.11+ parses the `.gitignore` file in the current working directory for
 exclude patterns if the `--exclude` parameter is unused and if there are no
 exclude patterns in the pyproject.toml file.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pathspec >= 0.12.1
+tomli >= 1.1.0; python_version < '3.11'

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ def find_version(*parts):
 with open("README.md") as f1, open("CHANGELOG.md") as f2:
     long_description = f1.read() + "\n\n" + f2.read()
 
+with open("requirements.txt") as f:
+    install_requires = f.read().splitlines()
+
 setuptools.setup(
     name="vulture",
     version=find_version("vulture", "version.py"),
@@ -47,10 +50,7 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    install_requires=[
-        "tomli >= 1.1.0; python_version < '3.11'",
-        "pathspec >= 0.12.1",
-    ],
+    install_requires=install_requires,
     entry_points={"console_scripts": ["vulture = vulture.core:main"]},
     python_requires=">=3.8",
     packages=setuptools.find_packages(exclude=["tests"]),

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     ],
     install_requires=[
         "tomli >= 1.1.0; python_version < '3.11'",
-        "pathspec >= 0.12.1; python_version >= '3.8'",
+        "pathspec >= 0.12.1",
     ],
     entry_points={"console_scripts": ["vulture = vulture.core:main"]},
     python_requires=">=3.8",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ setuptools.setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    install_requires=["tomli >= 1.1.0; python_version < '3.11'"],
+    install_requires=[
+        "tomli >= 1.1.0; python_version < '3.11'",
+        "pathspec >= 0.12.1",
+    ],
     entry_points={"console_scripts": ["vulture = vulture.core:main"]},
     python_requires=">=3.8",
     packages=setuptools.find_packages(exclude=["tests"]),

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     ],
     install_requires=[
         "tomli >= 1.1.0; python_version < '3.11'",
-        "pathspec >= 0.12.1",
+        "pathspec >= 0.12.1; python_version >= '3.8'",
     ],
     entry_points={"console_scripts": ["vulture = vulture.core:main"]},
     python_requires=">=3.8",

--- a/tests/test_gitignore_patterns.py
+++ b/tests/test_gitignore_patterns.py
@@ -1,0 +1,56 @@
+import os
+import pathlib
+import pytest
+import shutil
+
+from . import call_vulture
+from vulture.utils import ExitCode
+
+
+class TempGitignore:
+    def __init__(self, patterns):
+        self.patterns = patterns
+        root = pathlib.Path(".").resolve()
+        self.file = root / ".gitignore"
+        self.tmpfile = root / ".tmp_gitignore"
+
+    def __enter__(self):
+        shutil.move(self.file, self.tmpfile)
+        with open(self.file, "w") as f:
+            f.write("\n".join(self.patterns))
+
+        return self.file
+
+    def __exit__(self, *args):
+        os.remove(self.file)
+        shutil.move(self.tmpfile, self.file)
+
+
+@pytest.fixture(scope="function")
+def gitignore(request):
+    with TempGitignore(request.param) as fpath:
+        yield fpath
+
+
+@pytest.mark.parametrize(
+    "exclude_patterns,gitignore,exit_code",
+    (
+        ([], [], ExitCode.NoDeadCode),
+        ([""], [], ExitCode.NoDeadCode),
+        ([], [""], ExitCode.NoDeadCode),
+        ([""], ["core.py", "utils.py"], ExitCode.NoDeadCode),
+        (["core.py", "utils.py"], [""], ExitCode.DeadCode),
+        ([], ["core.py", "utils.py"], ExitCode.DeadCode),
+    ),
+    indirect=("gitignore",),
+)
+def test_gitignore(exclude_patterns, gitignore, exit_code):
+    def get_csv(paths):
+        return ",".join(os.path.join("vulture", path) for path in paths)
+
+    cli_args = ["vulture/"]
+    if exclude_patterns:
+        cli_args.extend(["--exclude", get_csv(exclude_patterns)])
+
+    assert gitignore.is_file()
+    assert call_vulture(cli_args) == exit_code

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -1,12 +1,12 @@
 import ast
 from fnmatch import fnmatch, fnmatchcase
 from pathlib import Path
-from pathspec import PathSpec
 import pkgutil
 import re
 import string
 import sys
 
+from pathspec import PathSpec
 from vulture import lines
 from vulture import noqa
 from vulture import utils
@@ -274,8 +274,8 @@ class Vulture(ast.NodeVisitor):
         gitignore = _get_gitignore_pathspec()
 
         def exclude_path(path):
-            # if no exclude patterns are provided through the cli arguments or
-            # a toml file, use .gitignore patterns to inform exclusion
+            # If no exclude patterns are provided via the CLI or
+            # a TOML file, use .gitignore patterns to inform exclusion.
             return (
                 _match(path, exclude, case=False)
                 if exclude


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Use .gitignore to exclude files if --exclude is missing from both
pyproject.toml and the command line. Vulture now requires the
pathspec library to run.


## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->
#344 

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
