### PR TITLE
Bugfix: Handle when .gitignore is not present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Switch to tomllib/tomli to support heterogeneous arrays (Sebastian Csar, #340).
 * Provide whitelist parity for `MagicMock` and `Mock` (maxrake).
 * Use .gitignore to exclude files if --exclude is missing from both pyproject.toml and the command line (whosayn, #344, #345).
+* Properly detect when no .gitignore is present (travisdart, #346).
 
 # 2.10 (2023-10-06)
 

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -116,7 +116,7 @@ def _ignore_variable(filename, varname):
 
 
 def _get_gitignore_pathspec():
-    if (gitignore := Path(".gitignore").resolve()).is_file:
+    if (gitignore := Path(".gitignore").resolve()).is_file():
         with gitignore.open() as fh:
             return PathSpec.from_lines("gitwildmatch", fh)
     return PathSpec.from_lines("gitwildmatch", [])


### PR DESCRIPTION
I cloned the Vulture repo and created the `dead_code.py` file in the `tests/` directory. I ran Vulture with: ` python ../vulture/__main__.py dead_code.py` (maybe there's a more elegant way; I dunno), and I got this error:

```
$  python ../vulture/__main__.py dead_code.py
Traceback (most recent call last):
  File "/Users/travis.dart/PycharmProjects/vulture/tests/../vulture/__main__.py", line 3, in <module>
    main()
  File "/Users/travis.dart/PycharmProjects/vulture/vulture/core.py", line 751, in main
    vulture.scavenge(config["paths"], exclude=config["exclude"])
  File "/Users/travis.dart/PycharmProjects/vulture/vulture/core.py", line 274, in scavenge
    gitignore = _get_gitignore_pathspec()
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/travis.dart/PycharmProjects/vulture/vulture/core.py", line 120, in _get_gitignore_pathspec
    with gitignore.open() as fh:
         ^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.4/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pathlib.py", line 1044, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/Users/travis.dart/PycharmProjects/vulture/tests/.gitignore'
```

I found that there's an error in the function that detects the `.gitignore` file. Basically, we need `is_file()` instead of `is_file`.
```
(Pdb) Path(".gitignore").resolve().is_file
<bound method Path.is_file of PosixPath('/Users/travis.dart/PycharmProjects/vulture/tests/.gitignore')>
(Pdb) bool(Path(".gitignore").resolve().is_file)
True
(Pdb) Path(".gitignore").resolve().is_file()
False
```

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [ ] I have added or adapted tests to cover my changes.
- [ ] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
