### PR TITLE
Use ruff for linting

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.1
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.1.1
-    # - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.1.1
-    - uses: actions/setup-python@v5
+    # - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,18 +6,8 @@ repos:
         language_version: python3
         exclude: rednotebook/external/.*\.py
 
-  - repo: https://github.com/pycqa/flake8
-    rev: '6.1.0'
-    hooks:
-      - id: flake8
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.28.0
-    hooks:
-      - id: pyupgrade
-        exclude: rednotebook/external/.*\.py
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.13
     hooks:
       - id: ruff
+        exclude: rednotebook/external/.*\.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
     hooks:
       - id: pyupgrade
         exclude: rednotebook/external/.*\.py
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.13
+    hooks:
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 88
+line-length = 79
 indent-width = 4
 
 # Assume Python 3.8
@@ -60,7 +60,7 @@ target-version = "py38"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "B"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -69,6 +69,9 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+"vulture/whitelists/*.py" = ["B108"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,32 +21,19 @@ exclude = '''
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".git-rewrite",
-    ".hg",
-    ".ipynb_checkpoints",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pyenv",
-    ".pytest_cache",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    ".vscode",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "site-packages",
-    "venv",
+  ".eggs",
+  ".git",
+  "_build",
+  "build",
+  "dist",
+  "htmlcov",
+  "vulture.egg-info",
+  ".cache",
+  ".coverag",
+  ".pytest_cache",
+  ".tox",
+  ".venv",
+  ".vscode",
 ]
 
 # Same as Black.
@@ -56,10 +43,16 @@ indent-width = 4
 target-version = "py38"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "B", "C4", "UP", "W", "C901"]
+# ruff enables Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = [
+  "F", # pyflakes
+  "E4", "E7", "E9", # pycodestyle
+  "B", # flake8-bugbear
+  "C4", # comprehensions
+  "UP", # pyupgrade
+]
 ignore = [
-  # C408: unnecessary dict call
-  "C408",
+  "C408", # unnecessary dict call
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,15 +53,14 @@ exclude = [
 line-length = 79
 indent-width = 4
 
-# Assume Python 3.8
 target-version = "py38"
 
 [tool.ruff.lint]
-# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
-# McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "B"]
-ignore = []
+select = ["E4", "E7", "E9", "F", "B", "C4", "UP", "W", "C901"]
+ignore = [
+  # C408: unnecessary dict call
+  "C408",
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -71,7 +70,7 @@ unfixable = []
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
-"vulture/whitelists/*.py" = ["B108"]
+"vulture/whitelists/*.py" = ["B018"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,82 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/tox.ini
+++ b/tox.ini
@@ -30,28 +30,20 @@ filterwarnings =
 basepython = python3
 deps =
   black==22.3.0
-  flake8==6.1.0
-  flake8-2020==1.7.0
-  flake8-bugbear==23.9.16
-  flake8-comprehensions==3.14.0
-  pyupgrade==2.28.0
   ruff==0.1.13
 allowlist_externals =
   bash
 commands =
   black --check --diff .
-  # B028: use !r conversion flag
-  # C408: unnecessary dict call
-  flake8 --extend-ignore=B028,C408 setup.py tests/ vulture/
-  bash -c "pyupgrade --py38-plus `find dev/ tests/ vulture/ -name '*.py'` setup.py"
+  ruff .
 
 [testenv:fix-style]
 basepython = python3
 deps =
   black==22.3.0
-  pyupgrade==2.28.0
+  ruff==0.1.13
 allowlist_externals =
   bash
 commands =
   black .
-  bash -c "pyupgrade --py38-plus --exit-zero `find dev/ tests/ vulture/ -name '*.py'` setup.py"
+  ruff . --fix

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
   flake8-bugbear==23.9.16
   flake8-comprehensions==3.14.0
   pyupgrade==2.28.0
+  ruff==0.1.13
 allowlist_externals =
   bash
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,6 @@ basepython = python3
 deps =
   black==22.3.0
   ruff==0.1.13
-allowlist_externals =
-  bash
 commands =
   black --check --diff .
   ruff .
@@ -42,8 +40,6 @@ basepython = python3
 deps =
   black==22.3.0
   ruff==0.1.13
-allowlist_externals =
-  bash
 commands =
   black .
   ruff . --fix

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -256,7 +256,7 @@ class Vulture(ast.NodeVisitor):
             except SyntaxError as err:
                 handle_syntax_error(err)
 
-    def scavenge(self, paths, exclude=None):  # noqa: C901
+    def scavenge(self, paths, exclude=None):
         def prepare_pattern(pattern):
             if not any(char in pattern for char in "*?["):
                 pattern = f"*{pattern}*"

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -256,7 +256,7 @@ class Vulture(ast.NodeVisitor):
             except SyntaxError as err:
                 handle_syntax_error(err)
 
-    def scavenge(self, paths, exclude=None):
+    def scavenge(self, paths, exclude=None):  # noqa: C901
         def prepare_pattern(pattern):
             if not any(char in pattern for char in "*?["):
                 pattern = f"*{pattern}*"

--- a/vulture/utils.py
+++ b/vulture/utils.py
@@ -108,7 +108,7 @@ def read_file(filename):
         with tokenize.open(filename) as f:
             return f.read()
     except (SyntaxError, UnicodeDecodeError) as err:
-        raise VultureInputException(err)
+        raise VultureInputException from err
 
 
 class LoggingList(list):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hello, 

This MR configures [ruff](https://github.com/astral-sh/ruff), an extremely fast Python linter and code formatter to `vulture`. `ruff` can potentially replace all the current linting and formatting tools, namely `black`, `flake8` and `pyupgrade`.

The current config in `pyproject.toml` is the default one, I put it there for ease of your review and customization. 

Let me know if this change is welcome. I can make further adjustments to the config to suit `vulture` style if needed.

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [ ] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
