### PR TITLE
Use ruff for formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@
 - [ ] I have updated the documentation in the README.md file or my changes don't require an update.
 - [ ] I have added an entry in CHANGELOG.md.
 - [ ] I have added or adapted tests to cover my changes.
-- [ ] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
+- [ ] I have run `pre-commit run --all-files` to format and lint my code.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,6 @@ jobs:
     - name: Run tests
       run: python -m tox -e py
 
-    - name: Check style
-      if: ${{ matrix.python-version == 3.10 && startsWith(matrix.os, 'ubuntu') }}
-      run: python -m tox -e style
-
     - name: Report coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,8 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
-        language_version: python3
-        exclude: rednotebook/external/.*\.py
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.13
     hooks:
       - id: ruff
+        exclude: rednotebook/external/.*\.py
+      - id: ruff-format
         exclude: rednotebook/external/.*\.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# next (unreleased)
+
+* Use `ruff` for linting (Anh Trinh, #347).
+* Use `ruff` for formatting (Anh Trinh, #349).
+* Replace `tox` by `pre-commit` for linting and formatting (Anh Trinh, #349).
+
 # 2.11 (2024-01-06)
 * Switch to tomllib/tomli to support heterogeneous arrays (Sebastian Csar, #340).
 * Bump flake8, flake8-comprehensions and flake8-bugbear (Sebastian Csar, #341).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,12 @@ of "Fixed issue12.". Please make sure that you only fix the issue at hand
 or implement the desired new feature instead of making "drive-by" changes
 like adding type hints.
 
+### Formating and linting
+
+Run `pre-commit` using:
+
+    $ pre-commit run --all-files
+
 ## Testing
 
 Run `tox` using:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,21 +3,6 @@
 # verbose regular expressions by Black.  Use [ ] to denote a significant space
 # character.
 
-[tool.black]
-line-length = 79
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-)/
-'''
-
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/tox.ini
+++ b/tox.ini
@@ -25,21 +25,3 @@ wheel_build_env = .pkg
 filterwarnings =
   error::DeprecationWarning
   error::PendingDeprecationWarning
-
-[testenv:style]
-basepython = python3
-deps =
-  black==22.3.0
-  ruff==0.1.13
-commands =
-  black --check --diff .
-  ruff .
-
-[testenv:fix-style]
-basepython = python3
-deps =
-  black==22.3.0
-  ruff==0.1.13
-commands =
-  black .
-  ruff . --fix


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Use `ruff` for formatting
* Use `pre-commit` instead of `tox` to run linting and formatting task.

I took the liberty to combine both changes into 1 PR as they are quite short, especially the replacement of `tox` by `pre-commit`

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [ ] I have added or adapted tests to cover my changes.
- [ ] I have run `tox -e fix-style` to format my code and checked the result with `tox -e style`.
