### PR TITLE
Add --config parameter to specify pyproject.toml path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Use `ruff` for linting (Anh Trinh, #347).
 * Use `ruff` for formatting (Anh Trinh, #349).
 * Replace `tox` by `pre-commit` for linting and formatting (Anh Trinh, #349).
-* Add `-c` flag to specify path to pyproject.toml configuration file (Glen Robertson #352).
+* Add `--config` flag to specify path to pyproject.toml configuration file (Glen Robertson #352).
 
 # 2.11 (2024-01-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Use `ruff` for linting (Anh Trinh, #347).
 * Use `ruff` for formatting (Anh Trinh, #349).
 * Replace `tox` by `pre-commit` for linting and formatting (Anh Trinh, #349).
+* Add `-c` flag to specify path to pyproject.toml configuration file (Glen Robertson #352).
 
 # 2.11 (2024-01-06)
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ sort_by_size = true
 verbose = true
 ```
 
+`vulture` will automatically look for a `pyproject.toml` in the current working directory.
+
+To use a `pyproject.toml` in another directory, you can use the `-c path/to/pyproject.toml` flag.
+
 ## Version control integration
 
 You can use a [pre-commit](https://pre-commit.com/#install) hook to run

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ sort_by_size = true
 verbose = true
 ```
 
-`vulture` will automatically look for a `pyproject.toml` in the current working directory.
+Vulture will automatically look for a `pyproject.toml` in the current working directory.
 
 To use a `pyproject.toml` in another directory, you can use the `--config path/to/pyproject.toml` flag.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ verbose = true
 
 `vulture` will automatically look for a `pyproject.toml` in the current working directory.
 
-To use a `pyproject.toml` in another directory, you can use the `-c path/to/pyproject.toml` flag.
+To use a `pyproject.toml` in another directory, you can use the `--config path/to/pyproject.toml` flag.
 
 ## Version control integration
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,6 +182,9 @@ def test_toml_config_custom_path():
 
     Test file is in tests/toml/mock_pyproject.toml
     """
+    tomlfile_path = os.path.join(
+        os.path.dirname(__file__), "toml", "mock_pyproject.toml"
+    )
     tomlfile_path = os.path.join(os.path.dirname(__file__), "toml", "mock_pyproject.toml")
     cliargs = [
         f"--config={tomlfile_path}",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,9 @@ Unit tests for config file and CLI argument parsing.
 """
 
 from io import BytesIO
+import pathlib
 from textwrap import dedent
 
-import pathlib
 import pytest
 
 from vulture.config import (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,8 @@ Unit tests for config file and CLI argument parsing.
 """
 
 from io import BytesIO
-import tempfile
 from textwrap import dedent
+import os
 
 import pytest
 
@@ -179,24 +179,16 @@ def test_toml_config_custom_path():
     """
     Ensure that TOML pyproject.toml files can be read from a custom path,
     other than the current working directory.
+
+    Test file is in tests/toml/mock_pyproject.toml
     """
-    with tempfile.NamedTemporaryFile("w") as tomlfile:
-        tomlfile.write(
-            dedent(
-                """\
-            [tool.vulture]
-            verbose = true
-            ignore_names = ["name_from_toml_file"]
-            """
-            )
-        )
-        tomlfile.flush()
-        cliargs = [
-            f"--config={tomlfile.name}",
-            "cli_path",
-        ]
-        result = make_config(cliargs)
-        assert result["ignore_names"] == ["name_from_toml_file"]
+    tomlfile_path = os.path.join(os.path.dirname(__file__), "toml", "mock_pyproject.toml")
+    cliargs = [
+        f"--config={tomlfile_path}",
+        "cli_path",
+    ]
+    result = make_config(cliargs)
+    assert result["ignore_names"] == ["name_from_toml_file"]
 
 
 def test_config_merging_missing():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,7 +185,6 @@ def test_toml_config_custom_path():
     tomlfile_path = os.path.join(
         os.path.dirname(__file__), "toml", "mock_pyproject.toml"
     )
-    tomlfile_path = os.path.join(os.path.dirname(__file__), "toml", "mock_pyproject.toml")
     cliargs = [
         f"--config={tomlfile_path}",
         "cli_path",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,8 @@ Unit tests for config file and CLI argument parsing.
 
 from io import BytesIO
 from textwrap import dedent
-import os
 
+import pathlib
 import pytest
 
 from vulture.config import (
@@ -182,9 +182,8 @@ def test_toml_config_custom_path():
 
     Test file is in tests/toml/mock_pyproject.toml
     """
-    tomlfile_path = os.path.join(
-        os.path.dirname(__file__), "toml", "mock_pyproject.toml"
-    )
+    here = pathlib.Path(__file__).parent
+    tomlfile_path = here.joinpath("toml", "mock_pyproject.toml")
     cliargs = [
         f"--config={tomlfile_path}",
         "cli_path",

--- a/tests/toml/mock_pyproject.toml
+++ b/tests/toml/mock_pyproject.toml
@@ -1,0 +1,5 @@
+# This file exists for the test case: test_config::test_toml_config_custom_path
+
+[tool.vulture]
+verbose = true
+ignore_names = ["name_from_toml_file"]

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -14,6 +14,7 @@ from .version import __version__
 
 #: Possible configuration options and their respective defaults
 DEFAULTS = {
+    "config": "pyproject.toml",
     "min_confidence": 0,
     "paths": [],
     "exclude": [],
@@ -159,6 +160,12 @@ def _parse_args(args=None):
         help="Sort unused functions and classes by their lines of code.",
     )
     parser.add_argument(
+        "-c", "--config",
+        type=str,
+        default="pyproject.toml",
+        help="Path to pyproject.toml config file",
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", default=missing
     )
     parser.add_argument("--version", action="version", version=version)
@@ -195,7 +202,7 @@ def make_config(argv=None, tomlfile=None):
         config = _parse_toml(tomlfile)
         detected_toml_path = str(tomlfile)
     else:
-        toml_path = pathlib.Path("pyproject.toml").resolve()
+        toml_path = pathlib.Path(cli_config["config"]).resolve()
         if toml_path.is_file():
             with open(toml_path, "rb") as fconfig:
                 config = _parse_toml(fconfig)

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -163,7 +163,7 @@ def _parse_args(args=None):
         "--config",
         type=str,
         default="pyproject.toml",
-        help="Path to pyproject.toml config file",
+        help="Path to pyproject.toml config file.",
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", default=missing

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -160,7 +160,7 @@ def _parse_args(args=None):
         help="Sort unused functions and classes by their lines of code.",
     )
     parser.add_argument(
-        "-c", "--config",
+        "--config",
         type=str,
         default="pyproject.toml",
         help="Path to pyproject.toml config file",


### PR DESCRIPTION

## Description
For projects that have a pyproject.toml config in a directory other than the root, this allows `vulture` to accept `--config path/to/pyproject.toml` (or `-c path/to/pyproject.toml`).

## Related Issue
No issue created or found.

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `pre-commit run --all-files` to format and lint my code.
