### PR TITLE
Ignore self calls

### DIFF
--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,0 +1,90 @@
+from . import check, v
+
+assert v  # Silence pyflakes.
+
+
+def test_recursion1(v):
+    v.scan(
+        """\
+def Rec():
+    Rec()
+"""
+    )
+    check(v.defined_funcs, ["Rec"])
+    check(v.unused_funcs, ["Rec"])
+
+
+def test_recursion2(v):
+    v.scan(
+        """\
+def Rec():
+    Rec()
+
+class MyClass:
+    def __init__(self):
+        pass
+
+    def Rec():
+        Rec() # calls global Rec()
+
+def main():
+    main()
+"""
+    )
+    check(v.defined_funcs, ["Rec", "Rec", "main"])
+    check(v.unused_funcs, ["main"])
+
+
+def test_recursion3(v):
+    v.scan(
+        """\
+class MyClass:
+    def __init__(self):
+        pass
+
+    def Rec():
+        pass
+
+def Rec():
+    MyClass.Rec()
+"""
+    )
+    check(v.defined_funcs, ["Rec", "Rec"])
+    check(v.unused_funcs, [])
+    # MyClass.Rec() is not treated as a recursive call. So, MyClass.Rec is marked as used, causing Rec to also
+    # be marked as used (in Vulture's current behaviour) since they share the same name.
+
+
+def test_recursion4(v):
+    v.scan(
+        """\
+def Rec():
+    Rec()
+
+class MyClass:
+    def __init__(self):
+        pass
+
+    def Rec():
+        pass
+"""
+    )
+    check(v.defined_funcs, ["Rec", "Rec"])
+    check(v.unused_funcs, ["Rec", "Rec"])
+
+
+def test_recursion5(v):
+    v.scan(
+        """\
+def rec():
+    if (5 > 4):
+        rec()
+
+def outer():
+    def inner():
+        outer() # these calls aren't considered for recursion
+        inner()
+"""
+    )
+    check(v.defined_funcs, ["rec", "outer", "inner"])
+    check(v.unused_funcs, ["rec"])

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -643,7 +643,7 @@ class Vulture(ast.NodeVisitor):
         if (
             isinstance(node.ctx, (ast.Load, ast.Del))
             and node.id not in IGNORED_VARIABLE_NAMES
-            and not utils.recursive_call(node)
+            and not utils.top_lvl_recursive_call(node)
         ):
             self.used_names.add(node.id)
         elif isinstance(node.ctx, (ast.Param, ast.Store)):

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -250,7 +250,8 @@ class Vulture(ast.NodeVisitor):
             )
             self.exit_code = ExitCode.InvalidInput
         else:
-            # When parsing type comments, visiting can throw SyntaxError.
+            utils.add_parent_info(node)
+            # When parsing type comments, visiting can throw a SyntaxError:
             try:
                 self.visit(node)
             except SyntaxError as err:
@@ -642,6 +643,7 @@ class Vulture(ast.NodeVisitor):
         if (
             isinstance(node.ctx, (ast.Load, ast.Del))
             and node.id not in IGNORED_VARIABLE_NAMES
+            and not utils.recursive_call(node)
         ):
             self.used_names.add(node.id)
         elif isinstance(node.ctx, (ast.Param, ast.Store)):


### PR DESCRIPTION
This PR makes it so that top level functions calling themselves don't count as cases of the function being used. This partially fixes #354, but only for top level functions.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [ ] I have updated the documentation in the README.md file or my changes don't require an update.
- [ ] I have added an entry in CHANGELOG.md.
- [ ] I have added or adapted tests to cover my changes.
- [ ] I have run `pre-commit run --all-files` to format and lint my code.
