### PR TITLE
Remove `pass_filenames: false` from pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,5 @@
   entry: vulture
   description: Find unused Python code.
   types: [python]
-  pass_filenames: false
   require_serial: true
   


### PR DESCRIPTION
To make the vulture pre-commit hook work on the specific files specified by pre-commit and not on the entire repo, I need to override the config it as shown [here](https://github.com/luminartech/dev-tools/pull/43/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R159), with `pass_filenames: true`. I argue that this is a saner default than `pass_filenames: false`, so let's remove it from vulture's pre-commit hook.

## Related Issue

https://github.com/luminartech/dev-tools/pull/43

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `pre-commit run --all-files` to format and lint my code.
