### PR TITLE
Handle while True loops without break statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # next (unreleased)
 
+* Handle `while True` loops without `break` statements (kreathon).
 * Improve reachability analysis (kreathon, #270, #302).
 * Add type hints for `get_unused_code` and the fields of the `Item` class (John Doknjas, #361).
 

--- a/tests/test_reachability.py
+++ b/tests/test_reachability.py
@@ -731,13 +731,77 @@ else:
     check_unreachable(v, 4, 1, "else")
 
 
+def test_while_true_no_fall_through(v):
+    v.scan(
+        """\
+while True:
+    raise Exception() 
+print(":-(")
+"""
+    )
+    check_unreachable(v, 3, 1, "while")
+
+
+def test_while_true_no_fall_through_nested(v):
+    v.scan(
+        """\
+while True:
+    if a > 3:
+        raise Exception() 
+    else:
+        pass
+print(":-(")
+"""
+    )
+    check_unreachable(v, 6, 1, "while")
+
+
+def test_while_true_no_fall_through_nested_loops(v):
+    v.scan(
+        """\
+while True:
+    for _ in range(3):
+        break
+    while False:
+        break
+print(":-(")
+"""
+    )
+    check_multiple_unreachable(v, [(4, 2, "while"), (6, 1, "while")])
+
+
+def test_while_true_fall_through(v):
+    v.scan(
+        """\
+while True:
+    break 
+print(":-)")
+"""
+    )
+    assert v.unreachable_code == []
+
+
+def test_while_true_fall_through_nested(v):
+    v.scan(
+        """\
+while True:
+    if a > 3:
+        raise Exception() 
+    else:
+        break
+print(":-(")
+"""
+    )
+    assert v.unreachable_code == []
+
+
 def test_while_fall_through(v):
     v.scan(
         """\
 def foo(a):
     while a > 0:
         return 1
-    print(":-(")
+    print(":-)")
 """
     )
     assert v.unreachable_code == []


### PR DESCRIPTION
## Description

In the following example, the `print` statement is not recognized as unreachable code by `vulture`. 

```
while True:
    raise Exception()
print("Currently not recognized!")
```

More general: If a `while True` statement has no `break`, then the statement after the `while True` is unreachable.

## Implementation

Introduce `self._current_loop_has_break_statement` in order to keep track of `break` statements found while traversing the AST. 

We cannot validate if the break statements only occur in loops (so we need to assume the code is correct). In order to check this properly, we would need to visit the parent first (and push some kind of context or scope; pop if after visiting the children).


## Checklist

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `pre-commit run --all-files` to format and lint my code.
