### PR TITLE
Add forward reference annotation detection

### DIFF
--- a/tests/test_annotations_parser.py
+++ b/tests/test_annotations_parser.py
@@ -1,0 +1,22 @@
+import typing
+
+import pytest
+
+from vulture.annotation_parser import AnnotationParser
+
+
+@pytest.mark.parametrize(
+    "input_annotation, expected_types",
+    [
+        ("Foo", {"Foo"}),
+        ("foo.Foo", {"foo", "Foo"}),
+        ("List['Foo', 'Bar']", {"List", "Foo", "Bar"}),
+        ('List["Foo", "Bar"]', {"List", "Foo", "Bar"}),
+        ("List['foo.Foo', 'foo.Bar']", {"List", "foo", "Foo", "Bar"}),
+    ],
+)
+def test_different_nested_annotations(
+    input_annotation: str, expected_types: typing.Set[str]
+):
+    parser = AnnotationParser(input_annotation)
+    assert parser.parse() == expected_types

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -309,3 +309,63 @@ unused_var = 'monty'
     )
     check(v.unused_imports, [])
     check(v.unused_vars, ["unused_var"])
+
+
+def test_plain_forward_reference_args(v):
+    v.scan(
+        """\
+from foo import Foo, Bar, Baz
+
+def bar(a: "Foo", /, b: "Bar", *, c: "Baz"):
+    ...
+"""
+    )
+    check(v.unused_imports, [])
+
+
+def test_plain_forward_reference_return_type(v):
+    v.scan(
+        """\
+from foo import Foo
+
+def bar() -> "Foo":
+    ...
+"""
+    )
+    check(v.unused_imports, [])
+
+
+def test_plain_forward_reference_with_module(v):
+    v.scan(
+        """\
+import foo
+
+def bar() -> "foo.Foo":
+    ...
+"""
+    )
+    check(v.unused_imports, [])
+
+
+def test_nested_forward_reference_outer_double_quotes(v):
+    v.scan(
+        """\
+from foo import Foo
+
+def bar() -> "List['Foo']":
+    ...
+"""
+    )
+    check(v.unused_imports, [])
+
+
+def test_nested_forward_reference_outer_single_quotes(v):
+    v.scan(
+        """\
+from foo import Foo
+
+def bar() -> 'List["Foo"]':
+    ...
+"""
+    )
+    check(v.unused_imports, [])

--- a/vulture/annotation_parser.py
+++ b/vulture/annotation_parser.py
@@ -1,0 +1,36 @@
+import tokenize
+from io import StringIO
+from typing import List, Set
+
+
+class AnnotationParser:
+    def __init__(self, annotation_string: str):
+        self._annotation = annotation_string
+
+    def parse(self) -> Set[str]:
+        type_names = set()
+        token_generator = tokenize.generate_tokens(
+            StringIO(self._annotation).readline
+        )
+
+        for token in token_generator:
+            token_type = token.type
+            token_string = token.string
+
+            if token_type == tokenize.NAME:
+                type_names.add(token_string)
+            elif token_type == tokenize.STRING:
+                for type_name in self._parse_string(token_string):
+                    type_names.add(type_name)
+
+        return type_names
+
+    @staticmethod
+    def _parse_string(token_string: str) -> List[str]:
+        first_char = token_string[0]
+        if first_char == "'" or first_char == '"':
+            type_name = token_string[1:-1]
+        else:
+            type_name = token_string
+
+        return type_name.split(".")

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import List
 
 from vulture import lines, noqa, utils
+from vulture.annotation_parser import AnnotationParser
 from vulture.config import InputError, make_config
 from vulture.reachability import Reachability
 from vulture.utils import ExitCode
@@ -596,6 +597,21 @@ class Vulture(ast.NodeVisitor):
             self._define(
                 self.defined_funcs, node.name, node, ignore=_ignore_function
             )
+
+        for arg in (
+            node.args.args + node.args.kwonlyargs + node.args.posonlyargs
+        ):
+            self._add_constant_annotation(arg.annotation)
+
+        if node.returns:
+            self._add_constant_annotation(node.returns)
+
+    def _add_constant_annotation(self, annotation: ast.AST):
+        if utils.is_ast_string(annotation):
+            annotation: ast.Constant
+            annotation_parser = AnnotationParser(annotation.value)
+            for name in annotation_parser.parse():
+                self.used_names.add(name)
 
     def visit_Import(self, node):
         self._add_aliases(node)


### PR DESCRIPTION
Adding support for parsing forward references in type annotations and using them for the detection algorithm.

## Description
Hi, I'd like to add the support for [forward references](https://peps.python.org/pep-0484/#forward-references) so I would appreciate it if you could take a look at this draft.

I understand that [it has been discussed](https://github.com/jendrikseipp/vulture/tree/main?tab=readme-ov-file#forward-references-for-type-annotations) but I think it's worth reconsidering, given the timeframe (the original discussion is from 2020) and further adoption of new Python versions.

Personally, this blocks the usage of Vulture as it either forces you to adopt a new standard (`from __future__ import annotations` instead of `if TYPE_CHECKING:...`) or deal with a lot of false positives if you don't (or can't).

I know that in the original discussion, there's been concerns about the issues that this could open up so I've tried to cover some basic cases but I'm all for for covering more.

Let me know if this approach makes sense to you. 

## Related Issue
- https://github.com/jendrikseipp/vulture/issues/216

## Checklist:

- [ ] I have updated the documentation in the README.md file or my changes don't require an update.
- [ ] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `pre-commit run --all-files` to format and lint my code.
