### PR TITLE
Ignoring ignore_class_attrs on flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Drop support for Python 3.8 (Jendrik Seipp, #398).
 * Add support for Python 3.14 (even-even).
 
+# 2.15 (2025-03-15)
+
+* Added --ignore-attributes-for-classes flag (Tesla2000, #383).
+
 # 2.14 (2024-12-08)
 
 * Improve reachability analysis (kreathon, #270, #302).

--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ When using the `--sort-by-size` option, Vulture sorts unused code by its
 number of lines. This helps developers prioritize where to look for dead
 code first.
 
+## Ignore attributes for classes
+
+When using the `--ignore-attributes-for-classes` option, 
+Vulture suppresses unused class attributes.
+
 ## Examples
 
 Consider the following Python script (`dead_code.py`):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ def test_cli_args():
         exclude=["file*.py", "dir/"],
         ignore_decorators=["deco1", "deco2"],
         ignore_names=["name1", "name2"],
+        ignore_attributes_for_classes=["class_name1", "class_name2"],
         config="pyproject.toml",
         make_whitelist=True,
         min_confidence=10,
@@ -45,6 +46,7 @@ def test_cli_args():
             "--exclude=file*.py,dir/",
             "--ignore-decorators=deco1,deco2",
             "--ignore-names=name1,name2",
+            "--ignore-attributes-for-classes=class_name1,class_name2",
             "--make-whitelist",
             "--min-confidence=10",
             "--sort-by-size",
@@ -142,6 +144,7 @@ def test_config_merging():
         exclude = ["toml_exclude"]
         ignore_decorators = ["toml_deco"]
         ignore_names = ["toml_name"]
+        ignore_attributes_for_classes = ["toml_class_name"]
         make_whitelist = false
         min_confidence = 10
         sort_by_size = false
@@ -154,6 +157,7 @@ def test_config_merging():
         "--exclude=cli_exclude",
         "--ignore-decorators=cli_deco",
         "--ignore-names=cli_name",
+        "--ignore-attributes-for-classes=cli_class_name",
         "--make-whitelist",
         "--min-confidence=20",
         "--sort-by-size",
@@ -166,6 +170,7 @@ def test_config_merging():
         exclude=["cli_exclude"],
         ignore_decorators=["cli_deco"],
         ignore_names=["cli_name"],
+        ignore_attributes_for_classes=["cli_class_name"],
         config="pyproject.toml",
         make_whitelist=True,
         min_confidence=20,

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -3,11 +3,14 @@ from vulture import core
 from . import check
 
 
-def check_ignore(code, ignore_names, ignore_decorators, expected):
+def check_ignore(
+    code, ignore_names, ignore_decorators, ignore_class_attrs, expected
+):
     v = core.Vulture(
         verbose=True,
         ignore_names=ignore_names,
         ignore_decorators=ignore_decorators,
+        ignore_class_attrs=ignore_class_attrs,
     )
     v.scan(code)
     check(v.get_unused_code(), expected)
@@ -22,7 +25,42 @@ ftobar = 3
 baz = 10000
 funny = True
 """
-    check_ignore(code, ["f?o*", "ba[rz]"], [], ["funny"])
+    check_ignore(code, ["f?o*", "ba[rz]"], [], [], ["funny"])
+
+
+def test_var_and_attrs():
+    code = """\
+class Foo1:
+    foo1: str
+    foo2: str = ""
+    foo3 = None
+    foo4, foo5 = None, None
+class Foo2:
+    foo6: str
+    foo7: str = ""
+    foo8 = None
+    foo9, foo0 = None, None
+funny = True
+foo1 = None
+"""
+    check_ignore(code, [], [], ["Foo*"], ["Foo1", "Foo2", "funny", "foo1"])
+    check_ignore(
+        code,
+        [],
+        [],
+        ["Foo1"],
+        [
+            "Foo1",
+            "Foo2",
+            "funny",
+            "foo6",
+            "foo7",
+            "foo8",
+            "foo9",
+            "foo0",
+            "foo1",
+        ],
+    )
 
 
 def test_function():
@@ -36,7 +74,7 @@ def foo():
 def bar():
     pass
 """
-    check_ignore(code, ["foo*"], [], ["bar"])
+    check_ignore(code, ["foo*"], [], [], ["bar"])
 
 
 def test_async_function():
@@ -46,7 +84,7 @@ async def foobar():
 async def bar():
     pass
 """
-    check_ignore(code, ["foo*"], [], ["bar"])
+    check_ignore(code, ["foo*"], [], [], ["bar"])
 
 
 def test_class():
@@ -55,7 +93,7 @@ class Foo:
     def __init__(self):
         pass
 """
-    check_ignore(code, ["Foo"], [], [])
+    check_ignore(code, ["Foo"], [], [], [])
 
 
 def test_class_ignore():
@@ -67,7 +105,7 @@ class Foo:
 class Bar:
     pass
 """
-    check_ignore(code, [], [], ["Foo", "Bar"])
+    check_ignore(code, [], [], [], ["Foo", "Bar"])
 
 
 def test_property():
@@ -82,8 +120,8 @@ class Foo:
     def foo_bar(self):
         return 'bar'
 """
-    check_ignore(code, ["Foo"], ["@property"], [])
-    check_ignore(code, ["Foo"], [], ["some_property", "foo_bar"])
+    check_ignore(code, ["Foo"], ["@property"], [], [])
+    check_ignore(code, ["Foo"], [], [], ["some_property", "foo_bar"])
 
 
 def test_attribute():
@@ -93,7 +131,7 @@ class Foo:
         self._attr_foo = attr_foo
         self._attr_bar = attr_bar
 """
-    check_ignore(code, ["foo", "*_foo"], [], ["Foo", "_attr_bar"])
+    check_ignore(code, ["foo", "*_foo"], [], [], ["Foo", "_attr_bar"])
 
 
 def test_decorated_functions():
@@ -125,8 +163,8 @@ def foo():
 def barfoo():
     pass
 """
-    check_ignore(code, [], ["@decor", "*@f.foobar"], ["prop_one"])
-    check_ignore(code, [], ["*decor", "@*f.foobar"], ["prop_one"])
+    check_ignore(code, [], ["@decor", "*@f.foobar"], [], ["prop_one"])
+    check_ignore(code, [], ["*decor", "@*f.foobar"], [], ["prop_one"])
 
 
 def test_decorated_async_functions():
@@ -140,7 +178,7 @@ async def async_function():
 async def foo():
     pass
 """
-    check_ignore(code, [], ["@app.route", "@a.b"], ["foo"])
+    check_ignore(code, [], ["@app.route", "@a.b"], [], ["foo"])
 
 
 def test_decorated_property():
@@ -150,9 +188,9 @@ def test_decorated_property():
 def foo():
     pass
 """
-    check_ignore(code, [], ["@bar"], [])
-    check_ignore(code, [], ["@baz"], ["foo"])
-    check_ignore(code, [], ["@property"], [])
+    check_ignore(code, [], ["@bar"], [], [])
+    check_ignore(code, [], ["@baz"], [], ["foo"])
+    check_ignore(code, [], ["@property"], [], [])
 
 
 def test_decorated_property_reversed():
@@ -162,10 +200,10 @@ def test_decorated_property_reversed():
 def foo():
     pass
 """
-    check_ignore(code, [], ["@bar"], [])
-    check_ignore(code, [], ["@property"], [])
-    check_ignore(code, [], ["@b*r"], [])
-    check_ignore(code, [], ["@barfoo"], ["foo"])
+    check_ignore(code, [], ["@bar"], [], [])
+    check_ignore(code, [], ["@property"], [], [])
+    check_ignore(code, [], ["@b*r"], [], [])
+    check_ignore(code, [], ["@barfoo"], [], ["foo"])
 
 
 def test_decorated_class():
@@ -176,5 +214,5 @@ class Bar:
     def __init__(self):
         pass
 """
-    check_ignore(code, [], [], ["Bar"])
-    check_ignore(code, [], ["@bar*"], [])
+    check_ignore(code, [], [], [], ["Bar"])
+    check_ignore(code, [], ["@bar*"], [], [])

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -5,6 +5,7 @@ command-line arguments or the pyproject.toml file.
 
 import argparse
 import pathlib
+from typing import TypedDict
 
 try:
     import tomllib
@@ -21,10 +22,24 @@ DEFAULTS = {
     "exclude": [],
     "ignore_decorators": [],
     "ignore_names": [],
+    "ignore_attributes_for_classes": [],
     "make_whitelist": False,
     "sort_by_size": False,
     "verbose": False,
 }
+
+
+class _Config(TypedDict, total=False):
+    config: str
+    min_confidence: int
+    paths: list
+    exclude: list
+    ignore_decorators: list
+    ignore_names: list
+    ignore_attributes_for_classes: list
+    make_whitelist: bool
+    sort_by_size: bool
+    verbose: bool
 
 
 class InputError(Exception):
@@ -32,7 +47,7 @@ class InputError(Exception):
         self.message = message
 
 
-def _check_input_config(data):
+def _check_input_config(data: _Config):
     """
     Checks the types of the values in *data* against the expected types of
     config-values. If a value has the wrong type, raise an InputError.
@@ -58,7 +73,7 @@ def _check_output_config(config):
         raise InputError("Please pass at least one file or directory")
 
 
-def _parse_toml(infile):
+def _parse_toml(infile) -> _Config:
     """
     Parse a TOML file for config values.
 
@@ -141,6 +156,14 @@ def _parse_args(args=None):
         f" {glob_help}",
     )
     parser.add_argument(
+        "--ignore-attributes-for-classes",
+        metavar="PATTERNS",
+        type=csv,
+        default=missing,
+        help=f"Comma-separated list of class names to ignore (e.g., "
+        f' visit_*,do_*"). {glob_help}',
+    )
+    parser.add_argument(
         "--make-whitelist",
         action="store_true",
         default=missing,
@@ -180,7 +203,7 @@ def _parse_args(args=None):
     return cli_args
 
 
-def make_config(argv=None, tomlfile=None):
+def make_config(argv=None, tomlfile=None) -> _Config:
     """
     Returns a config object for vulture, merging both ``pyproject.toml`` and
     CLI arguments (CLI arguments have precedence).

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -3,9 +3,12 @@ import pkgutil
 import re
 import string
 import sys
+from collections.abc import Container, Iterable
 from fnmatch import fnmatch, fnmatchcase
 from functools import partial
+from itertools import chain
 from pathlib import Path
+from typing import Optional
 
 from vulture import lines, noqa, utils
 from vulture.config import InputError, make_config
@@ -40,12 +43,94 @@ ERROR_CODES = {
 }
 
 
-def _get_unused_items(defined_items, used_names):
-    unused_items = [
-        item for item in set(defined_items) if item.name not in used_names
-    ]
-    unused_items.sort(key=lambda item: item.name.lower())
-    return unused_items
+class Item:
+    """
+    Hold the name, type and location of defined code.
+    """
+
+    __slots__ = (
+        "confidence",
+        "filename",
+        "first_lineno",
+        "last_lineno",
+        "message",
+        "name",
+        "node",
+        "typ",
+    )
+
+    def __init__(
+        self,
+        name,
+        typ,
+        filename,
+        first_lineno,
+        last_lineno,
+        message="",
+        confidence=DEFAULT_CONFIDENCE,
+        node=None,
+    ):
+        self.name: str = name
+        self.typ: str = typ
+        self.filename: Path = filename
+        self.first_lineno: int = first_lineno
+        self.last_lineno: int = last_lineno
+        self.message: str = message or f"unused {typ} '{name}'"
+        self.confidence: int = confidence
+        self.node: Optional[ast.Name] = node
+
+    @property
+    def size(self):
+        assert self.last_lineno >= self.first_lineno
+        return self.last_lineno - self.first_lineno + 1
+
+    def get_report(self, add_size=False):
+        if add_size:
+            line_format = "line" if self.size == 1 else "lines"
+            size_report = f", {self.size:d} {line_format}"
+        else:
+            size_report = ""
+        return (
+            f"{utils.format_path(self.filename)}:{self.first_lineno:d}: "
+            f"{self.message} ({self.confidence}% confidence{size_report})"
+        )
+
+    def get_whitelist_string(self):
+        filename = utils.format_path(self.filename)
+        if self.typ == "unreachable_code":
+            return f"# {self.message} ({filename}:{self.first_lineno})"
+        prefix = ""
+        if self.typ in ["attribute", "method", "property"]:
+            prefix = "_."
+        return (
+            f"{prefix}{self.name}  # unused {self.typ} "
+            f"({filename}:{self.first_lineno:d})"
+        )
+
+    def _tuple(self):
+        return self.filename, self.first_lineno, self.name
+
+    def __repr__(self):
+        return repr(self.name)
+
+    def __eq__(self, other):
+        return self._tuple() == other._tuple()
+
+    def __hash__(self):
+        return hash(self._tuple())
+
+
+def _get_unused_items(
+    defined_items: Iterable[Item], used_names: Container
+) -> list[Item]:
+    return sorted(
+        [
+            item
+            for item in frozenset(defined_items)
+            if item.name not in used_names
+        ],
+        key=lambda item: item.name.lower(),
+    )
 
 
 def _is_special_name(name):
@@ -113,85 +198,15 @@ def _ignore_variable(filename, varname):
     )
 
 
-class Item:
-    """
-    Hold the name, type and location of defined code.
-    """
-
-    __slots__ = (
-        "confidence",
-        "filename",
-        "first_lineno",
-        "last_lineno",
-        "message",
-        "name",
-        "typ",
-    )
-
-    def __init__(
-        self,
-        name,
-        typ,
-        filename,
-        first_lineno,
-        last_lineno,
-        message="",
-        confidence=DEFAULT_CONFIDENCE,
-    ):
-        self.name: str = name
-        self.typ: str = typ
-        self.filename: Path = filename
-        self.first_lineno: int = first_lineno
-        self.last_lineno: int = last_lineno
-        self.message: str = message or f"unused {typ} '{name}'"
-        self.confidence: int = confidence
-
-    @property
-    def size(self):
-        assert self.last_lineno >= self.first_lineno
-        return self.last_lineno - self.first_lineno + 1
-
-    def get_report(self, add_size=False):
-        if add_size:
-            line_format = "line" if self.size == 1 else "lines"
-            size_report = f", {self.size:d} {line_format}"
-        else:
-            size_report = ""
-        return (
-            f"{utils.format_path(self.filename)}:{self.first_lineno:d}: "
-            f"{self.message} ({self.confidence}% confidence{size_report})"
-        )
-
-    def get_whitelist_string(self):
-        filename = utils.format_path(self.filename)
-        if self.typ == "unreachable_code":
-            return f"# {self.message} ({filename}:{self.first_lineno})"
-        prefix = ""
-        if self.typ in ["attribute", "method", "property"]:
-            prefix = "_."
-        return (
-            f"{prefix}{self.name}  # unused {self.typ} "
-            f"({filename}:{self.first_lineno:d})"
-        )
-
-    def _tuple(self):
-        return self.filename, self.first_lineno, self.name
-
-    def __repr__(self):
-        return repr(self.name)
-
-    def __eq__(self, other):
-        return self._tuple() == other._tuple()
-
-    def __hash__(self):
-        return hash(self._tuple())
-
-
 class Vulture(ast.NodeVisitor):
     """Find dead code."""
 
     def __init__(
-        self, verbose=False, ignore_names=None, ignore_decorators=None
+        self,
+        verbose=False,
+        ignore_names=None,
+        ignore_decorators=None,
+        ignore_class_attrs=None,
     ):
         self.verbose = verbose
 
@@ -211,6 +226,7 @@ class Vulture(ast.NodeVisitor):
 
         self.ignore_names = ignore_names or []
         self.ignore_decorators = ignore_decorators or []
+        self.ignore_class_attrs = ignore_class_attrs or []
 
         self.filename = Path()
         self.code = []
@@ -456,6 +472,7 @@ class Vulture(ast.NodeVisitor):
                     lines.get_last_line_number(last_node),
                     message=message,
                     confidence=confidence,
+                    node=first_node,
                 )
             )
 
@@ -548,6 +565,37 @@ class Vulture(ast.NodeVisitor):
         )
 
     def visit_ClassDef(self, node):
+        def get_attrs(elem) -> Iterable[ast.Name]:
+            if isinstance(elem, ast.Name):
+                yield elem
+                return
+            if isinstance(elem, ast.AnnAssign):
+                yield elem.target
+                return
+            if not isinstance(elem, (ast.Assign, ast.Tuple)):
+                return
+            elts = []
+            if isinstance(elem, ast.Tuple):
+                elts = elem.elts
+            for target in elts or elem.targets:
+                yield from get_attrs(target)
+
+        if any(
+            re.findall(pattern, node.name)
+            for pattern in self.ignore_class_attrs
+        ):
+            class_attrs = frozenset(
+                chain.from_iterable(map(get_attrs, node.body))
+            )
+            tuple(
+                map(
+                    self.defined_vars.remove,
+                    filter(
+                        lambda item: item.node in class_attrs,
+                        tuple(self.defined_vars),
+                    ),
+                )
+            )
         for decorator in node.decorator_list:
             if _match(
                 utils.get_decorator_name(decorator), self.ignore_decorators
@@ -672,6 +720,7 @@ def main():
         verbose=config["verbose"],
         ignore_names=config["ignore_names"],
         ignore_decorators=config["ignore_decorators"],
+        ignore_class_attrs=config["ignore_attributes_for_classes"],
     )
     vulture.scavenge(config["paths"], exclude=config["exclude"])
     sys.exit(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added --ignore-attributes-for-classes option accoridng to suggestion presented in #383. I have some missgivings about the approach. I think we shouldn't mark all attributes of a class as used as we can be skipping attributes variables with the same name that are not in a class. Correct me if I am worng. I have designed the coutermeasure to this issue.
<!--- Describe your changes in detail -->

## Related Issue
Add --ignore-attributes-for-classes option. #383
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `pre-commit run --all-files` to format and lint my code.
