### PR TITLE
Adds cls to IGNORED_VARIABLE_NAMES

### DIFF
--- a/vulture/core.py
+++ b/vulture/core.py
@@ -15,7 +15,7 @@ from vulture.utils import ExitCode
 
 DEFAULT_CONFIDENCE = 60
 
-IGNORED_VARIABLE_NAMES = {"object", "self"}
+IGNORED_VARIABLE_NAMES = {"object", "self", "cls"}
 PYTEST_FUNCTION_NAMES = {
     "setup_module",
     "teardown_module",


### PR DESCRIPTION
cls variable, together with self, is typically used in within classmethod decorators, and it should be also ignored

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Just added cls to the IGNORED_VARIABLE_NAMES global variable.
## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [ ] I have added an entry in CHANGELOG.md.
- [ ] I have added or adapted tests to cover my changes.
- [ ] I have run `pre-commit run --all-files` to format and lint my code.
