### PR TITLE
Add colour to vulture CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.17 (unreleased)
+
+* Colour output and add `-c`/`--color {yes,no,auto}` option (#415, Hugo van Kemenade).
+
 # 2.16 (2026-03-25)
 
 * Fix false positives for dead code after while loops (#412, #413, Jendrik Seipp).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ tool for higher code quality.
 * tested: tests itself and has complete test coverage
 * complements pyflakes and has the same output syntax
 * sorts unused classes and functions by size with `--sort-by-size`
+* colour output, with confidence shown via a temperature gradient
 
 ## Installation
 
@@ -163,6 +164,16 @@ def foo(arg: Sequence):
     ...
 ```
 
+
+## Colour output
+
+Output is in colour by default when stdout is a terminal. The
+confidence percentage uses a temperature gradient: 60% dark grey, 90%
+yellow, 100% red.
+
+Use `-c`/`--color {yes,no,auto}` to force colour on or off, or set the
+[`NO_COLOR`](https://no-color.org/) or
+[`FORCE_COLOR`](https://force-color.org/) environment variables.
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
+  "termcolor >= 2.3.0",
   "tomli >= 1.1.0; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+termcolor >= 2.3.0
 tomli >= 2.4.1; python_version < '3.11'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -166,6 +166,7 @@ def test_config_merging():
         exclude=["cli_exclude"],
         ignore_decorators=["cli_deco"],
         ignore_names=["cli_name"],
+        color="auto",
         config="pyproject.toml",
         make_whitelist=True,
         min_confidence=20,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -33,7 +33,7 @@ def check_report(v, capsys):
         filename = "foo.py"
         v.scan(code, filename=filename)
         capsys.readouterr()
-        ret = v.report(make_whitelist=make_whitelist)
+        ret = v.report(make_whitelist=make_whitelist, color="no")
         assert ret
         assert capsys.readouterr().out == expected.format(filename=filename)
 
@@ -59,6 +59,13 @@ def test_item_report(check_report):
 {filename}:18: unused function 'myfunc' (60% confidence)
 """
     check_report(mock_code, expected)
+
+
+def test_color(v):
+    v.scan("import os\n")
+    [item] = v.get_unused_code()
+    assert "\x1b[" in item.get_report(color="yes")
+    assert "\x1b[" not in item.get_report(color="no")
 
 
 def test_make_whitelist(check_report):

--- a/vulture/config.py
+++ b/vulture/config.py
@@ -15,6 +15,7 @@ from .version import __version__
 
 #: Possible configuration options and their respective defaults
 DEFAULTS = {
+    "color": "auto",
     "config": "pyproject.toml",
     "min_confidence": 0,
     "paths": [],
@@ -25,6 +26,8 @@ DEFAULTS = {
     "sort_by_size": False,
     "verbose": False,
 }
+
+COLOR_CHOICES = ("yes", "no", "auto")
 
 
 class InputError(Exception):
@@ -56,6 +59,10 @@ def _check_output_config(config):
     """
     if not config["paths"]:
         raise InputError("Please pass at least one file or directory")
+    if config["color"] not in COLOR_CHOICES:
+        raise InputError(
+            f"color must be one of {COLOR_CHOICES}, got {config['color']!r}"
+        )
 
 
 def _parse_toml(infile):
@@ -159,6 +166,13 @@ def _parse_args(args=None):
         action="store_true",
         default=missing,
         help="Sort unused functions and classes by their lines of code.",
+    )
+    parser.add_argument(
+        "-c",
+        "--color",
+        choices=COLOR_CHOICES,
+        default=missing,
+        help="Colour the output (default: auto).",
     )
     parser.add_argument(
         "--config",

--- a/vulture/core.py
+++ b/vulture/core.py
@@ -7,6 +7,8 @@ from fnmatch import fnmatch, fnmatchcase
 from functools import partial
 from pathlib import Path
 
+from termcolor import colored
+
 from vulture import lines, noqa, utils
 from vulture.config import InputError, make_config
 from vulture.reachability import Reachability
@@ -151,16 +153,45 @@ class Item:
         assert self.last_lineno >= self.first_lineno
         return self.last_lineno - self.first_lineno + 1
 
-    def get_report(self, add_size=False):
+    def get_report(self, add_size=False, *, color="auto"):
         if add_size:
             line_format = "line" if self.size == 1 else "lines"
             size_report = f", {self.size:d} {line_format}"
         else:
             size_report = ""
-        return (
-            f"{utils.format_path(self.filename)}:{self.first_lineno:d}: "
-            f"{self.message} ({self.confidence}% confidence{size_report})"
+
+        no_color = color == "no"
+        force_color = color == "yes"
+
+        def c(text, *args, **kwargs):
+            return colored(
+                text,
+                *args,
+                no_color=no_color,
+                force_color=force_color,
+                **kwargs,
+            )
+
+        path = c(utils.format_path(self.filename), attrs=["bold"])
+        colon = c(":", "cyan")
+        lineno = f"{self.first_lineno:d}"
+        if self.confidence >= 100:
+            confidence_color = "red"
+        elif self.confidence >= 90:
+            confidence_color = "yellow"
+        else:
+            confidence_color = "dark_grey"
+        confidence = c(
+            f"({self.confidence}% confidence{size_report})", confidence_color
         )
+        if self.typ == "unreachable_code":
+            message = c(self.message, "red", attrs=["bold"])
+        else:
+            message = (
+                f"unused {c(self.typ, 'red', attrs=['bold'])} "
+                f"{c(repr(self.name), attrs=['bold'])}"
+            )
+        return f"{path}{colon}{lineno}{colon} {message} {confidence}"
 
     def get_whitelist_string(self):
         filename = utils.format_path(self.filename)
@@ -347,7 +378,11 @@ class Vulture(ast.NodeVisitor):
         )
 
     def report(
-        self, min_confidence=0, sort_by_size=False, make_whitelist=False
+        self,
+        min_confidence=0,
+        sort_by_size=False,
+        make_whitelist=False,
+        color="auto",
     ):
         """
         Print ordered list of Item objects to stdout.
@@ -358,7 +393,7 @@ class Vulture(ast.NodeVisitor):
             self._log(
                 item.get_whitelist_string()
                 if make_whitelist
-                else item.get_report(add_size=sort_by_size),
+                else item.get_report(add_size=sort_by_size, color=color),
                 force=True,
             )
             self.exit_code = ExitCode.DeadCode
@@ -679,5 +714,6 @@ def main():
             min_confidence=config["min_confidence"],
             sort_by_size=config["sort_by_size"],
             make_whitelist=config["make_whitelist"],
+            color=config["color"],
         )
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

https://github.com/albertas/deadcode has colour output, but is unmaintained and [doesn't support Python 3.14](https://github.com/albertas/deadcode/pull/27).

This PR adds colour to vulture's CLI output to make it easier to read:

<img width="589" height="264" alt="image" src="https://github.com/user-attachments/assets/59ce09f5-289f-4f30-b27e-6dff28b87cb9" />

This uses a colour scheme similar to flake8, so will be familiar to people.

It adds a `-c, --color {yes,no,auto}` option, defaulting to auto.

It uses the termcolor library, which disables colour when not in a TTY, so piped output has no ANSI codes. It also respects common env vars such as `NO_COLOR=1` and `FORCE_COLOR=1`: https://github.com/termcolor/termcolor#overrides

## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `pre-commit run --all-files` to format and lint my code.
