### PR TITLE
Add support for Python 3.15 and drop EOL 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
   schedule:
     # Run daily (* needs quotes).
     - cron: '0 4 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: 1
 
 jobs:
   test:
@@ -16,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -49,6 +49,6 @@ jobs:
       run: python -m tox -e py
 
     - name: Report coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v6
       with:
         files: ./coverage.xml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,9 +1,9 @@
 name: pre-commit
 
-on:
-  pull_request:
-  push:
-    branches: [main]
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,5 +9,5 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.1
-    - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@v6.0.2
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv and set up the Python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install the project
         run: uv sync --all-groups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.17 (unreleased)
+
+* Drop support for Python 3.9 (Hugo van Kemenade, #416).
+
 # 2.16 (2026-03-25)
 
 * Fix false positives for dead code after while loops (#412, #413, Jendrik Seipp).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Find dead code"
 readme = { file = "README.md", content-type = "text/markdown" }
 keywords = ["dead code removal"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE.txt" }
 authors = [
   { name = "Jendrik Seipp", email = "jendrikseipp@gmail.com" },
@@ -20,7 +20,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -75,7 +74,7 @@ exclude = [
 line-length = 79
 indent-width = 4
 
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 # ruff enables Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,7 +41,9 @@ def check_unreachable(v, lineno, size, name):
 
 def check_multiple_unreachable(v, checks):
     assert len(v.unreachable_code) == len(checks)
-    for item, (lineno, size, name) in zip(v.unreachable_code, checks):
+    for item, (lineno, size, name) in zip(
+        v.unreachable_code, checks, strict=True
+    ):
         assert item.first_lineno == lineno
         assert item.size == size
         assert item.name == name

--- a/tests/test_scavenging.py
+++ b/tests/test_scavenging.py
@@ -1,7 +1,3 @@
-import sys
-
-import pytest
-
 from vulture.utils import ExitCode
 
 from . import check, v
@@ -798,9 +794,6 @@ foo(1, 2)
     check(v.unused_funcs, [])
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="requires python3.10 or higher"
-)
 def test_match_class_simple(v):
     v.scan(
         """\
@@ -830,9 +823,6 @@ match x:
     check(v.unused_vars, ["u"])
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="requires python3.10 or higher"
-)
 def test_match_class_embedded(v):
     v.scan(
         """\
@@ -866,9 +856,6 @@ match x:
     check(v.unused_vars, ["u"])
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="requires python3.10 or higher"
-)
 def test_match_enum(v):
     v.scan(
         """\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Python 3.15 will be in beta next week
* Python 3.9 has been EOL since October 2025
* https://devguide.python.org/versions/


## Related Issue
<!--- Ideally, new features and changes are discussed in an issue first. -->
<!--- If there is a corresponding issue, link to it here. Otherwise, remove this section. -->

## Checklist:
<!--- Go over the following points, and put an `x` into all boxes that apply. -->

- [x] I have updated the documentation in the README.md file or my changes don't require an update.
- [x] I have added an entry in CHANGELOG.md.
- [x] I have added or adapted tests to cover my changes.
- [x] I have run `pre-commit run --all-files` to format and lint my code.
